### PR TITLE
feat: angles also highlight the related segments

### DIFF
--- a/src/components/layouts/InPlaceLayout.tsx
+++ b/src/components/layouts/InPlaceLayout.tsx
@@ -1,5 +1,9 @@
 import { Content } from "../../core/diagramContent";
-import { ProofTextItem, Step, StepMeta } from "../../core/types/stepTypes";
+import {
+  ProofTextItem,
+  SetupStepMeta,
+  StepMeta,
+} from "../../core/types/stepTypes";
 import { Reason } from "../../core/types/types";
 import { Question } from "../../questions/completeQuestions";
 import { GIVEN_ID, PROVE_ID, getReasonFn } from "../../theorems/utils";
@@ -7,9 +11,9 @@ import { AppPage } from "../InteractiveAppPage";
 
 export interface InPlaceLayoutProps {
   baseContent: (showPoints: boolean, frame?: string) => Content;
-  steps: Step[];
-  givens: StepMeta;
-  proves: StepMeta;
+  steps: StepMeta[];
+  givens: SetupStepMeta;
+  proves: SetupStepMeta;
   miniContent: Content;
   questions: Question[];
 }
@@ -41,7 +45,7 @@ export const InPlaceLayout = (props: InPlaceLayoutProps) => {
   props.steps.map((step, i) => {
     let textMeta = {};
     const s = ctx.addFrame(`s${i + 1}`);
-    step.meta.diagram(ctx, s, true);
+    step.diagram(ctx, s, true);
     if (step.dependsOn) {
       const depIds = step.dependsOn.map((i) => `s${i}`);
       ctx.reliesOn(s, depIds);
@@ -51,7 +55,7 @@ export const InPlaceLayout = (props: InPlaceLayoutProps) => {
     linkedTexts.push({
       ...textMeta,
       k: s,
-      v: step.meta.text({ ctx }),
+      v: step.text({ ctx }),
       reason: step.reason.title,
     });
   });

--- a/src/components/layouts/StaticLayout.tsx
+++ b/src/components/layouts/StaticLayout.tsx
@@ -1,7 +1,7 @@
 import { Content } from "../../core/diagramContent";
 import {
+  SetupStepMeta,
   StaticProofTextItem,
-  Step,
   StepMeta,
 } from "../../core/types/stepTypes";
 import { Reason } from "../../core/types/types";
@@ -12,9 +12,9 @@ import { StaticAppPage } from "../StaticAppPage";
 
 export interface StaticLayoutProps {
   baseContent: (showPoints: boolean, frame?: string) => Content;
-  steps: Step[];
-  givens: StepMeta;
-  proves: StepMeta;
+  steps: StepMeta[];
+  givens: SetupStepMeta;
+  proves: SetupStepMeta;
   questions: Question[];
 }
 
@@ -28,7 +28,7 @@ export const StaticLayout = (props: StaticLayoutProps) => {
   const texts: StaticProofTextItem[] = [];
   props.steps.map((step) => {
     texts.push({
-      stmt: step.meta.staticText(),
+      stmt: step.staticText(),
       reason: step.reason.title,
     });
     if (step.reason.body !== "" && step.reason.title !== Reasons.Given.title) {

--- a/src/core/templates/BaseAngle.tsx
+++ b/src/core/templates/BaseAngle.tsx
@@ -8,23 +8,22 @@ import { StepTextProps } from "../types/stepTypes";
 export class BaseAngle {
   static text = (props: StepTextProps, a: string, ticks?: Tick[]) => {
     const ang = props.ctx.getAngle(a);
-    const [a1s1, a1s2] = [`${a[0]}${a[1]}`, `${a[1]}${a[2]}`];
+    // add segments to highlight on hover list.
+    // If angle is named XYZ, segments will be XY and YZ.
     let deps: BaseGeometryObject[] = [
-      props.ctx.getSegment(a1s1),
-      props.ctx.getSegment(a1s2),
+      props.ctx.getSegment(a.substring(0, 2)),
+      props.ctx.getSegment(a.substring(1, 3)),
     ];
     if (ticks) {
       deps = deps.concat(ticks);
     }
     return linked(a, ang, deps);
   };
-  static ticklessText = (ctx: Content, a: string) => {
-    const [a1s1, a1s2] = [`${a[0]}${a[1]}`, `${a[1]}${a[2]}`];
-    return linked(a, ctx.getAngle(a), [
-      ctx.getSegment(a1s1),
-      ctx.getSegment(a1s2),
+  static ticklessText = (ctx: Content, a: string) =>
+    linked(a, ctx.getAngle(a), [
+      ctx.getSegment(a.substring(0, 2)),
+      ctx.getSegment(a.substring(1, 3)),
     ]);
-  };
   static staticText = (a: string) => {
     return angleStr(a);
   };

--- a/src/core/templates/BaseAngle.tsx
+++ b/src/core/templates/BaseAngle.tsx
@@ -1,0 +1,31 @@
+import { linked } from "../../theorems/utils";
+import { Content } from "../diagramContent";
+import { BaseGeometryObject } from "../geometry/BaseGeometryObject";
+import { Tick } from "../geometry/Tick";
+import { angleStr } from "../geometryText";
+import { StepTextProps } from "../types/stepTypes";
+
+export class BaseAngle {
+  static text = (props: StepTextProps, a: string, ticks?: Tick[]) => {
+    const ang = props.ctx.getAngle(a);
+    const [a1s1, a1s2] = [`${a[0]}${a[1]}`, `${a[1]}${a[2]}`];
+    let deps: BaseGeometryObject[] = [
+      props.ctx.getSegment(a1s1),
+      props.ctx.getSegment(a1s2),
+    ];
+    if (ticks) {
+      deps = deps.concat(ticks);
+    }
+    return linked(a, ang, deps);
+  };
+  static ticklessText = (ctx: Content, a: string) => {
+    const [a1s1, a1s2] = [`${a[0]}${a[1]}`, `${a[1]}${a[2]}`];
+    return linked(a, ctx.getAngle(a), [
+      ctx.getSegment(a1s1),
+      ctx.getSegment(a1s2),
+    ]);
+  };
+  static staticText = (a: string) => {
+    return angleStr(a);
+  };
+}

--- a/src/core/templates/EqualAngles.tsx
+++ b/src/core/templates/EqualAngles.tsx
@@ -28,17 +28,23 @@ export class EqualAngles {
     [a1, a2]: [string, string],
     num?: number
   ) => {
-    const a1a = props.ctx.getAngle(a1);
-    const a2a = props.ctx.getAngle(a2);
     const options = { frame: props.frame, num };
     return (
       <span>
         {BaseAngle.text(props, a1, [
-          props.ctx.getTick(a1a, Obj.EqualAngleTick, options),
+          props.ctx.getTick(
+            props.ctx.getAngle(a1),
+            Obj.EqualAngleTick,
+            options
+          ),
         ])}
         {congruent}
         {BaseAngle.text(props, a2, [
-          props.ctx.getTick(a2a, Obj.EqualAngleTick, options),
+          props.ctx.getTick(
+            props.ctx.getAngle(a2),
+            Obj.EqualAngleTick,
+            options
+          ),
         ])}
       </span>
     );

--- a/src/core/templates/EqualAngles.tsx
+++ b/src/core/templates/EqualAngles.tsx
@@ -1,8 +1,8 @@
-import { linked } from "../../theorems/utils";
 import { Content } from "../diagramContent";
 import { angleStr, congruent } from "../geometryText";
 import { StepFocusProps, StepTextProps } from "../types/stepTypes";
 import { Obj, SVGModes } from "../types/types";
+import { BaseAngle } from "./BaseAngle";
 
 export class EqualAngles {
   static additions = (
@@ -33,18 +33,22 @@ export class EqualAngles {
     const options = { frame: props.frame, num };
     return (
       <span>
-        {linked(a1, a1a, [props.ctx.getTick(a1a, Obj.EqualAngleTick, options)])}
+        {BaseAngle.text(props, a1, [
+          props.ctx.getTick(a1a, Obj.EqualAngleTick, options),
+        ])}
         {congruent}
-        {linked(a2, a2a, [props.ctx.getTick(a2a, Obj.EqualAngleTick, options)])}
+        {BaseAngle.text(props, a2, [
+          props.ctx.getTick(a2a, Obj.EqualAngleTick, options),
+        ])}
       </span>
     );
   };
   static ticklessText = (ctx: Content, [a1, a2]: [string, string]) => {
     return (
       <span>
-        {linked(a1, ctx.getAngle(a1))}
+        {BaseAngle.ticklessText(ctx, a1)}
         {congruent}
-        {linked(a2, ctx.getAngle(a2))}
+        {BaseAngle.ticklessText(ctx, a2)}
       </span>
     );
   };

--- a/src/core/templates/EqualRightAngles.tsx
+++ b/src/core/templates/EqualRightAngles.tsx
@@ -14,16 +14,18 @@ export class EqualRightAngles {
     RightAngle.additions({ ...props, mode: a2Mode || props.mode }, a2);
   };
   static text = (props: StepTextProps, [a1, a2]: [string, string]) => {
-    const a1a = props.ctx.getAngle(a1);
-    const a2a = props.ctx.getAngle(a2);
     return (
       <span>
         {BaseAngle.text(props, a1, [
-          props.ctx.getTick(a1a, Obj.RightTick, { frame: props.frame }),
+          props.ctx.getTick(props.ctx.getAngle(a1), Obj.RightTick, {
+            frame: props.frame,
+          }),
         ])}
         {this.equalNinety}
         {BaseAngle.text(props, a2, [
-          props.ctx.getTick(a2a, Obj.RightTick, { frame: props.frame }),
+          props.ctx.getTick(props.ctx.getAngle(a2), Obj.RightTick, {
+            frame: props.frame,
+          }),
         ])}
       </span>
     );

--- a/src/core/templates/EqualRightAngles.tsx
+++ b/src/core/templates/EqualRightAngles.tsx
@@ -1,11 +1,10 @@
-import { linked } from "../../theorems/utils";
-import { congruent } from "../geometryText";
 import { StepFocusProps, StepTextProps } from "../types/stepTypes";
 import { Obj, SVGModes } from "../types/types";
-import { EqualAngles } from "./EqualAngles";
+import { BaseAngle } from "./BaseAngle";
 import { RightAngle } from "./RightAngle";
 
 export class EqualRightAngles {
+  private static equalNinety = " = 90° = ";
   static additions = (
     props: StepFocusProps,
     [a1, a2]: [string, string],
@@ -15,21 +14,27 @@ export class EqualRightAngles {
     RightAngle.additions({ ...props, mode: a2Mode || props.mode }, a2);
   };
   static text = (props: StepTextProps, [a1, a2]: [string, string]) => {
-    const a1s = props.ctx.getAngle(a1);
-    const a2s = props.ctx.getAngle(a2);
+    const a1a = props.ctx.getAngle(a1);
+    const a2a = props.ctx.getAngle(a2);
     return (
       <span>
-        {linked(a1, a1s, [
-          props.ctx.getTick(a1s, Obj.RightTick, { frame: props.frame }),
+        {BaseAngle.text(props, a1, [
+          props.ctx.getTick(a1a, Obj.RightTick, { frame: props.frame }),
         ])}
-        {congruent}
-        {linked(a2, a2s, [
-          props.ctx.getTick(a2s, Obj.RightTick, { frame: props.frame }),
+        {this.equalNinety}
+        {BaseAngle.text(props, a2, [
+          props.ctx.getTick(a2a, Obj.RightTick, { frame: props.frame }),
         ])}
       </span>
     );
   };
   static staticText = (a: [string, string]) => {
-    return EqualAngles.staticText(a);
+    return (
+      <span>
+        {BaseAngle.staticText(a[0])}
+        {this.equalNinety}
+        {BaseAngle.staticText(a[1])}
+      </span>
+    );
   };
 }

--- a/src/core/templates/RightAngle.tsx
+++ b/src/core/templates/RightAngle.tsx
@@ -1,8 +1,8 @@
-import { linked } from "../../theorems/utils";
 import { Content } from "../diagramContent";
 import { angleStr } from "../geometryText";
 import { StepFocusProps, StepTextProps } from "../types/stepTypes";
 import { Obj } from "../types/types";
+import { BaseAngle } from "./BaseAngle";
 
 export class RightAngle {
   private static rightText = " = 90°";
@@ -17,7 +17,7 @@ export class RightAngle {
     const ang = props.ctx.getAngle(a);
     return (
       <span>
-        {linked(a, ang, [
+        {BaseAngle.text(props, a, [
           props.ctx.getTick(ang, Obj.RightTick, { frame: props.frame }),
         ])}
         {this.rightText}
@@ -27,7 +27,7 @@ export class RightAngle {
   static ticklessText = (ctx: Content, a: string) => {
     return (
       <span>
-        {linked(a, ctx.getAngle(a))}
+        {BaseAngle.ticklessText(ctx, a)}
         {this.rightText}
       </span>
     );

--- a/src/core/types/stepTypes.ts
+++ b/src/core/types/stepTypes.ts
@@ -13,11 +13,8 @@ export interface StepUnfocusProps {
   frame: string;
   inPlace: boolean;
 }
-export interface StepFocusProps {
-  ctx: Content;
-  frame: string;
+export interface StepFocusProps extends StepUnfocusProps {
   mode: SVGModes;
-  inPlace: boolean;
 }
 export interface StepTextProps {
   ctx: Content;

--- a/src/core/types/stepTypes.ts
+++ b/src/core/types/stepTypes.ts
@@ -36,11 +36,15 @@ export interface StaticProofTextItem {
   reason?: string;
 }
 
-export interface StepMeta {
+export interface SetupStepMeta {
   unfocused: (props: StepUnfocusProps) => void;
   diagram: (ctx: Content, frame: string, inPlace?: boolean) => void;
   text: (props: StepTextProps) => JSX.Element;
   ticklessText: (ctx: Content) => JSX.Element;
   staticText: () => JSX.Element;
   additions: (props: StepFocusProps) => void;
+}
+export interface StepMeta extends SetupStepMeta {
+  reason: Reason;
+  dependsOn?: number[];
 }

--- a/src/theorems/checking/pc1.tsx
+++ b/src/theorems/checking/pc1.tsx
@@ -123,6 +123,7 @@ const proves: StepMeta = makeStepMeta({
 });
 
 const step1: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -136,6 +137,7 @@ const step1: StepMeta = makeStepMeta({
 });
 
 const step2: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     const addProps = { ...props, mode: SVGModes.Unfocused };
     givens.additions(addProps);
@@ -151,6 +153,7 @@ const step2: StepMeta = makeStepMeta({
 });
 
 const step3: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     const addProps = { ...props, mode: SVGModes.Unfocused };
     givens.additions(addProps);
@@ -167,6 +170,8 @@ const step3: StepMeta = makeStepMeta({
 });
 
 const step4: StepMeta = makeStepMeta({
+  reason: Reasons.SAS,
+  dependsOn: [1, 2, 3],
   additions: (props: StepFocusProps) => {
     givens.additions(props);
     step1.additions(props);
@@ -185,6 +190,8 @@ const step4: StepMeta = makeStepMeta({
 });
 
 const step5: StepMeta = makeStepMeta({
+  reason: Reasons.CorrespondingAngles,
+  dependsOn: [4],
   unfocused: (props: StepUnfocusProps) => {
     step4.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -249,19 +256,5 @@ export const PC1: LayoutProps = {
   baseContent,
   givens,
   proves,
-  steps: [
-    { meta: step1, reason: Reasons.Given },
-    { meta: step2, reason: Reasons.Given },
-    { meta: step3, reason: Reasons.Given },
-    {
-      meta: step4,
-      reason: Reasons.SAS,
-      dependsOn: [1, 2, 3],
-    },
-    {
-      meta: step5,
-      reason: Reasons.CorrespondingAngles,
-      dependsOn: [4],
-    },
-  ],
+  steps: [step1, step2, step3, step4, step5],
 };

--- a/src/theorems/checking/pc2.tsx
+++ b/src/theorems/checking/pc2.tsx
@@ -105,6 +105,7 @@ const proves: StepMeta = makeStepMeta({
 });
 
 const step1: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -118,6 +119,7 @@ const step1: StepMeta = makeStepMeta({
 });
 
 const step2: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     const focusProps = { ...props, mode: SVGModes.Unfocused };
     givens.additions(focusProps);
@@ -133,6 +135,8 @@ const step2: StepMeta = makeStepMeta({
 });
 
 const step3: StepMeta = makeStepMeta({
+  reason: Reasons.CongAdjAngles,
+  dependsOn: [1],
   unfocused: (props: StepUnfocusProps) => {
     step2.unfocused(props);
     step2.additions({ ...props, mode: SVGModes.Unfocused });
@@ -147,6 +151,7 @@ const step3: StepMeta = makeStepMeta({
 });
 
 const step4: StepMeta = makeStepMeta({
+  reason: Reasons.Reflexive,
   unfocused: (props: StepUnfocusProps) => {
     step3.unfocused(props);
     step3.additions({ ...props, mode: SVGModes.Unfocused });
@@ -168,6 +173,8 @@ const step5Labels: SASProps = {
   tickOverride: Obj.RightTick,
 };
 const step5: StepMeta = makeStepMeta({
+  reason: Reasons.SAS,
+  dependsOn: [2, 3, 4],
   additions: (props: StepFocusProps) => {
     SAS.additions(props, step5Labels);
   },
@@ -220,13 +227,7 @@ export const miniContent = () => {
 export const PC2: LayoutProps = {
   questions: checkingProof2,
   baseContent,
-  steps: [
-    { meta: step1, reason: Reasons.Given },
-    { meta: step2, reason: Reasons.Given },
-    { meta: step3, reason: Reasons.CongAdjAngles, dependsOn: [1] },
-    { meta: step4, reason: Reasons.Reflexive },
-    { meta: step5, reason: Reasons.SAS, dependsOn: [2, 3, 4] },
-  ],
+  steps: [step1, step2, step3, step4, step5],
   miniContent: miniContent(),
   givens,
   proves,

--- a/src/theorems/checking/pc3.tsx
+++ b/src/theorems/checking/pc3.tsx
@@ -3,7 +3,7 @@ import { Angle } from "../../core/geometry/Angle";
 import { BaseGeometryObject } from "../../core/geometry/BaseGeometryObject";
 import { Point } from "../../core/geometry/Point";
 import { Triangle } from "../../core/geometry/Triangle";
-import { angleStr, comma } from "../../core/geometryText";
+import { comma } from "../../core/geometryText";
 import { EqualRightAngles } from "../../core/templates/EqualRightAngles";
 import { EqualSegments } from "../../core/templates/EqualSegments";
 import { EqualTriangles } from "../../core/templates/EqualTriangles";
@@ -135,6 +135,7 @@ const proves: StepMeta = makeStepMeta({
 });
 
 const step1: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -160,6 +161,7 @@ const step1: StepMeta = makeStepMeta({
 });
 
 const step2: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     step1.unfocused(props);
     step1.additions({ ...props, mode: SVGModes.Unfocused });
@@ -172,6 +174,7 @@ const step2: StepMeta = makeStepMeta({
 });
 
 const step3: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     step2.additions({ ...props, mode: SVGModes.Unfocused });
     step2.unfocused(props);
@@ -184,6 +187,8 @@ const step3: StepMeta = makeStepMeta({
 });
 
 const step4: StepMeta = makeStepMeta({
+  reason: Reasons.Rectangle,
+  dependsOn: [1],
   unfocused: (props: StepUnfocusProps) => {
     step3.unfocused(props);
     step3.additions({ ...props, mode: SVGModes.Unfocused });
@@ -192,29 +197,15 @@ const step4: StepMeta = makeStepMeta({
     EqualRightAngles.additions(props, ["KLM", "MNK"]);
   },
   text: (props: StepTextProps) => {
-    const MNK = props.ctx.getAngle("MNK");
-    return (
-      <span>
-        {RightAngle.text(props, "KLM")}
-        {" = "}
-        {linked("MNK", MNK, [
-          props.ctx.getTick(MNK, Obj.RightTick, { frame: props.frame }),
-        ])}
-      </span>
-    );
+    return EqualRightAngles.text(props, ["KLM", "MNK"]);
   },
   staticText: () => {
-    return (
-      <span>
-        {angleStr("KLM")}
-        {" = "}
-        {angleStr("MNK")}
-      </span>
-    );
+    return EqualRightAngles.staticText(["KLM", "MNK"]);
   },
 });
 
 const step5: StepMeta = makeStepMeta({
+  reason: Reasons.Reflexive,
   unfocused: (props: StepUnfocusProps) => {
     step4.unfocused(props);
     step4.additions({ ...props, mode: SVGModes.Unfocused });
@@ -234,6 +225,8 @@ const s6SASProps: SASProps = {
   tickOverride: Obj.RightTick,
 };
 const step6: StepMeta = makeStepMeta({
+  reason: Reasons.HL,
+  dependsOn: [2, 4, 5],
   additions: (props: StepFocusProps) => {
     SAS.additions(props, s6SASProps);
   },
@@ -288,14 +281,7 @@ export const PC3: LayoutProps = {
   questions: checkingProof3,
   baseContent,
   miniContent: miniContent(),
-  steps: [
-    { meta: step1, reason: Reasons.Given },
-    { meta: step2, reason: Reasons.Given },
-    { meta: step3, reason: Reasons.Given },
-    { meta: step4, reason: Reasons.Rectangle, dependsOn: [1] },
-    { meta: step5, reason: Reasons.Reflexive },
-    { meta: step6, reason: Reasons.HL, dependsOn: [2, 4, 5] },
-  ],
+  steps: [step1, step2, step3, step4, step5, step6],
   givens,
   proves,
 };

--- a/src/theorems/complete/proof1.tsx
+++ b/src/theorems/complete/proof1.tsx
@@ -141,6 +141,7 @@ const proves: StepMeta = makeStepMeta({
 });
 
 const step1: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -169,6 +170,7 @@ const step1: StepMeta = makeStepMeta({
 });
 
 const step2: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -207,6 +209,8 @@ const step2: StepMeta = makeStepMeta({
 });
 
 const step3: StepMeta = makeStepMeta({
+  reason: Reasons.VerticalAngles,
+  dependsOn: [2],
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
     step1.additions({ ...props, mode: SVGModes.Unfocused });
@@ -224,12 +228,16 @@ const step4SASProps: SASProps = {
   triangles: ["ACM", "BDM"],
 };
 const step4: StepMeta = makeStepMeta({
+  reason: Reasons.SAS,
+  dependsOn: [1, 3],
   additions: (props: StepFocusProps) => SAS.additions(props, step4SASProps),
   text: (props: StepTextProps) => SAS.text(props, step4SASProps),
   staticText: () => EqualTriangles.staticText(["ACM", "BDM"]),
 });
 
 const step5: StepMeta = makeStepMeta({
+  reason: Reasons.CorrespondingAngles,
+  dependsOn: [4],
   unfocused: (props: StepUnfocusProps) => {
     step4.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -240,6 +248,8 @@ const step5: StepMeta = makeStepMeta({
 });
 
 const step6: StepMeta = makeStepMeta({
+  reason: Reasons.AlternateInteriorAngles,
+  dependsOn: [5],
   unfocused: (props: StepUnfocusProps) => {
     step4.additions({ ...props, mode: SVGModes.Unfocused });
     step5.additions({ ...props, mode: SVGModes.Unfocused });
@@ -325,24 +335,5 @@ export const P1: LayoutProps = {
   baseContent,
   givens,
   proves,
-  steps: [
-    { meta: step1, reason: Reasons.Given },
-    { meta: step2, reason: Reasons.Given },
-    {
-      meta: step3,
-      reason: Reasons.VerticalAngles,
-      dependsOn: [2],
-    },
-    { meta: step4, reason: Reasons.SAS, dependsOn: [1, 3] },
-    {
-      meta: step5,
-      reason: Reasons.CorrespondingAngles,
-      dependsOn: [4],
-    },
-    {
-      meta: step6,
-      reason: Reasons.AlternateInteriorAngles,
-      dependsOn: [5],
-    },
-  ],
+  steps: [step1, step2, step3, step4, step5, step6],
 };

--- a/src/theorems/complete/proof3.tsx
+++ b/src/theorems/complete/proof3.tsx
@@ -4,7 +4,7 @@ import { BaseGeometryObject } from "../../core/geometry/BaseGeometryObject";
 import { Point } from "../../core/geometry/Point";
 import { Segment } from "../../core/geometry/Segment";
 import { Triangle } from "../../core/geometry/Triangle";
-import { angleStr, comma, triangleStr } from "../../core/geometryText";
+import { comma, triangleStr } from "../../core/geometryText";
 import { EqualAngles } from "../../core/templates/EqualAngles";
 import { EqualRightAngles } from "../../core/templates/EqualRightAngles";
 import { EqualSegments } from "../../core/templates/EqualSegments";
@@ -220,19 +220,8 @@ const step3: StepMeta = makeStepMeta({
   additions: (props: StepFocusProps) => {
     EqualRightAngles.additions(props, ["FEJ", "JHG"]);
   },
-  text: (props: StepTextProps) => {
-    // const JHG = props.ctx.getAngle("JHG");
-    return EqualRightAngles.text(props, ["FEJ", "JHG"]);
-  },
-  staticText: () => {
-    return (
-      <span>
-        {angleStr("FEJ")}
-        {" = "}
-        {angleStr("JHG")}
-      </span>
-    );
-  },
+  text: (props: StepTextProps) => EqualRightAngles.text(props, ["FEJ", "JHG"]),
+  staticText: () => EqualRightAngles.staticText(["FEJ", "JHG"]),
 });
 
 const step4: StepMeta = makeStepMeta({

--- a/src/theorems/complete/proof3.tsx
+++ b/src/theorems/complete/proof3.tsx
@@ -169,6 +169,7 @@ const proves: StepMeta = makeStepMeta({
 });
 
 const step1: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     givens.additions({ ...props, mode: SVGModes.Unfocused });
   },
@@ -197,6 +198,7 @@ const step1: StepMeta = makeStepMeta({
 });
 
 const step2: StepMeta = makeStepMeta({
+  reason: Reasons.Given,
   unfocused: (props: StepUnfocusProps) => {
     step1.unfocused(props);
     step1.additions({ ...props, mode: SVGModes.Unfocused });
@@ -209,6 +211,8 @@ const step2: StepMeta = makeStepMeta({
 });
 
 const step3: StepMeta = makeStepMeta({
+  reason: Reasons.Rectangle,
+  dependsOn: [1],
   unfocused: (props: StepUnfocusProps) => {
     step2.additions({ ...props, mode: SVGModes.Unfocused });
     step2.unfocused(props);
@@ -217,16 +221,8 @@ const step3: StepMeta = makeStepMeta({
     EqualRightAngles.additions(props, ["FEJ", "JHG"]);
   },
   text: (props: StepTextProps) => {
-    const JHG = props.ctx.getAngle("JHG");
-    return (
-      <span>
-        {RightAngle.text(props, "FEJ")}
-        {" = "}
-        {linked("JHG", JHG, [
-          props.ctx.getTick(JHG, Obj.RightTick, { frame: props.frame }),
-        ])}
-      </span>
-    );
+    // const JHG = props.ctx.getAngle("JHG");
+    return EqualRightAngles.text(props, ["FEJ", "JHG"]);
   },
   staticText: () => {
     return (
@@ -240,6 +236,8 @@ const step3: StepMeta = makeStepMeta({
 });
 
 const step4: StepMeta = makeStepMeta({
+  reason: Reasons.Parallelogram,
+  dependsOn: [3],
   unfocused: (props: StepUnfocusProps) => {
     step3.unfocused(props);
     step3.additions({ ...props, mode: SVGModes.Unfocused });
@@ -259,6 +257,8 @@ const step5SASProps: SASProps = {
   tickOverride: Obj.RightTick,
 };
 const step5: StepMeta = makeStepMeta({
+  reason: Reasons.SAS,
+  dependsOn: [2, 3, 4],
   unfocused: (props: StepUnfocusProps) => {
     props.ctx.getSegment("FG").mode(props.frame, SVGModes.Unfocused);
   },
@@ -270,6 +270,8 @@ const step5: StepMeta = makeStepMeta({
 });
 
 const step6: StepMeta = makeStepMeta({
+  reason: Reasons.CorrespondingSegments,
+  dependsOn: [5],
   unfocused: (props: StepUnfocusProps) => {
     step5.additions({ ...props, mode: SVGModes.Unfocused });
     step5.unfocused(props);
@@ -282,6 +284,8 @@ const step6: StepMeta = makeStepMeta({
 });
 
 const step7: StepMeta = makeStepMeta({
+  reason: Reasons.Isosceles,
+  dependsOn: [6],
   unfocused: (props: StepUnfocusProps) => {
     step6.additions({ ...props, mode: SVGModes.Unfocused });
     step6.unfocused(props);
@@ -390,17 +394,5 @@ export const P3: LayoutProps = {
   miniContent: miniContent(),
   givens,
   proves,
-  steps: [
-    { meta: step1, reason: Reasons.Given },
-    { meta: step2, reason: Reasons.Given },
-    { meta: step3, reason: Reasons.Rectangle, dependsOn: [1] },
-    { meta: step4, reason: Reasons.Parallelogram, dependsOn: [3] },
-    {
-      meta: step5,
-      reason: Reasons.SAS,
-      dependsOn: [2, 3, 4],
-    },
-    { meta: step6, reason: Reasons.CorrespondingSegments, dependsOn: [5] },
-    { meta: step7, reason: Reasons.Isosceles, dependsOn: [6] },
-  ],
+  steps: [step1, step2, step3, step4, step5, step6, step7],
 };

--- a/src/theorems/reasons.ts
+++ b/src/theorems/reasons.ts
@@ -1,4 +1,5 @@
 export const Reasons = {
+  Empty: { title: "", body: "" },
   Given: { title: "Given", body: "" },
   SAS: {
     title: "SAS Triangle Congruence",

--- a/src/theorems/utils.tsx
+++ b/src/theorems/utils.tsx
@@ -8,6 +8,7 @@ import {
   StepUnfocusProps,
 } from "../core/types/stepTypes";
 import { Reason, SVGModes } from "../core/types/types";
+import { Reasons } from "./reasons";
 
 export const GIVEN_ID = "given";
 export const PROVE_ID = "prove";
@@ -42,6 +43,8 @@ export const makeStepMeta = (meta: Partial<StepMeta>): StepMeta => {
   };
 
   return {
+    reason: meta.reason || Reasons.Empty,
+    dependsOn: meta.dependsOn,
     unfocused: meta.unfocused || defaultUnfocused,
     diagram,
     text: meta.text || defaultText,


### PR DESCRIPTION
Changes made:
* Angles highlight the 2 segments that create the angle on hover
* Refactored the `reasons` and `dependsOn` metadata for proof steps so they're defined in the same place as the visual elements