### PR TITLE
Add triangle reason checks

### DIFF
--- a/src/checker/checker/premises.ts
+++ b/src/checker/checker/premises.ts
@@ -54,7 +54,7 @@ export const buildPremises = (proof: ProofObj) => {
       case "isosceles":
       case "sim_tri":
       case "equilateral":
-      case "equilangular":
+      case "equiangular":
       case "seg_bisect":
       // TODO implement
       case "parallelogram":
@@ -183,7 +183,7 @@ export const buildPremises = (proof: ProofObj) => {
       case "sim_tri":
       case "con_tri":
       case "equilateral":
-      case "equilangular":
+      case "equiangular":
       case "rectangle":
         addAllObjects(ctx, statement);
         break;

--- a/src/checker/checker/premises.ts
+++ b/src/checker/checker/premises.ts
@@ -17,18 +17,11 @@ export const buildPremises = (proof: ProofObj) => {
   proof.premises.segments.forEach((segmentObj) => {
     ctx.addSegmentFromStr(segmentObj.v);
   });
-  // // loop through all pairs of points and create segments
-  // for (let i = 0; i < proof.premises.points.length; i++) {
-  //   const point1 = ctx.getPoint(proof.premises.points[i].v);
-  //   for (let j = i + 1; j < proof.premises.points.length; j++) {
-  //     const point2 = ctx.getPoint(proof.premises.points[j].v);
-  //     ctx.addSegment({ p1: point1, p2: point2 });
-  //   }
-  // }
 
   const addVisibleObjects = (ctx: ProofContent, statement: Stmt) => {
     switch (statement.function) {
       case "para":
+      case "sim_seg":
       case "con_seg":
         // TODO specify that something is being visually represented in given w this
         addAllObjects(ctx, statement);
@@ -58,15 +51,14 @@ export const buildPremises = (proof: ProofObj) => {
       // TODO implement
       case "con_tri":
       case "con_right":
-      case "para":
       case "isosceles":
       case "parallelogram":
-      case "sim_seg":
       case "sim_tri":
       case "equilateral":
       case "equilangular":
       case "seg_bisect":
       case "kite":
+      case "perp_bisector":
       case "isos_trapezoid":
       case "rhombus":
       case "trapezoid":
@@ -206,6 +198,7 @@ export const buildPremises = (proof: ProofObj) => {
       case "equilangular":
       case "seg_bisect":
       case "kite":
+      case "perp_bisector":
       case "isos_trapezoid":
       case "rhombus":
       case "trapezoid":

--- a/src/checker/checker/premises.ts
+++ b/src/checker/checker/premises.ts
@@ -23,12 +23,14 @@ export const buildPremises = (proof: ProofObj) => {
       case "para":
       case "sim_seg":
       case "con_seg":
-        // TODO specify that something is being visually represented in given w this
+      case "perp":
         addAllObjects(ctx, statement);
         break;
       case "on_line":
         onLine(ctx, statement.arguments);
         break;
+      case "perp_bisector": // all use (s1, s2, p)
+      case "seg_bisect":
       case "intersect_seg":
         intersectSeg(ctx, statement.arguments, proof);
         break;
@@ -46,17 +48,16 @@ export const buildPremises = (proof: ProofObj) => {
       case "ang_bisect":
       case "supplementary":
       case "complementary":
-      case "perp":
       case "rectangle":
-      // TODO implement
       case "con_tri":
       case "con_right":
       case "isosceles":
-      case "parallelogram":
       case "sim_tri":
       case "equilateral":
       case "equilangular":
       case "seg_bisect":
+      // TODO implement
+      case "parallelogram":
       case "kite":
       case "perp_bisector":
       case "isos_trapezoid":
@@ -174,31 +175,32 @@ export const buildPremises = (proof: ProofObj) => {
         break;
       case "con_ang":
       case "right":
+      case "con_right":
       case "complementary":
       case "supplementary":
       case "perp":
+      case "isosceles":
+      case "sim_tri":
+      case "con_tri":
+      case "equilateral":
+      case "equilangular":
       case "rectangle":
         addAllObjects(ctx, statement);
         break;
+      // require no additional objects
       case "con_seg":
       case "on_line":
+      case "seg_bisect":
+      case "perp_bisector":
       case "intersect_seg":
       case "transversal":
       case "midpt":
       case "linear_pair":
       case "para":
-      // TODO implement
-      case "con_tri":
-      case "con_right":
-      case "isosceles":
-      case "parallelogram":
       case "sim_seg":
-      case "sim_tri":
-      case "equilateral":
-      case "equilangular":
-      case "seg_bisect":
+      // TODO implement
       case "kite":
-      case "perp_bisector":
+      case "parallelogram":
       case "isos_trapezoid":
       case "rhombus":
       case "trapezoid":

--- a/src/checker/checker/reasonApplication.ts
+++ b/src/checker/checker/reasonApplication.ts
@@ -29,13 +29,20 @@ import {
 } from "./reasonChecks/lineChecks";
 import { def_parallelogram, rectangle } from "./reasonChecks/polyChecks";
 import {
+  checkAa,
   checkAas,
   checkAsa,
+  checkBaseAngle,
+  checkConTri,
   checkCpctc,
+  checkEquiangular,
+  checkEquilateral,
   checkIsosceles,
   checkRhl,
   checkSas,
   checkSss,
+  checkThirdAngle,
+  equilateralEquiangular,
 } from "./reasonChecks/triangleChecks";
 import { TriangleReasonFailure } from "./reasonChecks/triangleReasonResult";
 import { validateGivenProofStep } from "./validators";
@@ -500,22 +507,128 @@ export const checkReasonApplication = (
           );
         return true;
       }
+      case "def_con_tri": {
+        const s1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const s2 = getDepStmt(reason.arguments[1], proofGraph)!;
+        const s3 = getDepStmt(reason.arguments[2], proofGraph)!;
+        const a1 = getDepStmt(reason.arguments[3], proofGraph)!;
+        const a2 = getDepStmt(reason.arguments[4], proofGraph)!;
+        const a3 = getDepStmt(reason.arguments[5], proofGraph)!;
+        const r = checkConTri(s1, s2, s3, a1, a2, a3, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "third_angle": {
+        const a1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const a2 = getDepStmt(reason.arguments[1], proofGraph)!;
+        const r = checkThirdAngle(a1, a2, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "base_angle": {
+        const conSeg = getDepStmt(reason.arguments[0], proofGraph)!;
+        const r = checkBaseAngle(conSeg, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "base_angle_conv": {
+        const conAng = getDepStmt(reason.arguments[0], proofGraph)!;
+        const r = checkBaseAngle(conAng, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "equilat_equilang": {
+        const equilat = getDepStmt(reason.arguments[0], proofGraph)!;
+        const r = equilateralEquiangular(equilat, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "equilang_equilat": {
+        const equilang = getDepStmt(reason.arguments[0], proofGraph)!;
+        const r = equilateralEquiangular(stmt, equilang, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "def_equilangular": {
+        const a1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const a2 = getDepStmt(reason.arguments[1], proofGraph)!;
+        const a3 = getDepStmt(reason.arguments[2], proofGraph)!;
+        const r = checkEquiangular(a1, a2, a3, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "def_equilateral": {
+        const s1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const s2 = getDepStmt(reason.arguments[1], proofGraph)!;
+        const s3 = getDepStmt(reason.arguments[2], proofGraph)!;
+        const r = checkEquilateral(s1, s2, s3, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "sas_sim": {
+        const s1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const a = getDepStmt(reason.arguments[1], proofGraph)!;
+        const s2 = getDepStmt(reason.arguments[2], proofGraph)!;
+        const r = checkSas(stmt, s1, a, s2, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+
+      case "sss_sim": {
+        const s1_sss = getDepStmt(reason.arguments[0], proofGraph)!;
+        const s2_sss = getDepStmt(reason.arguments[1], proofGraph)!;
+        const s3_sss = getDepStmt(reason.arguments[2], proofGraph)!;
+        const r = checkSss(stmt, s1_sss, s2_sss, s3_sss, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
+      case "aa_sim": {
+        const a1 = getDepStmt(reason.arguments[0], proofGraph)!;
+        const a2 = getDepStmt(reason.arguments[1], proofGraph)!;
+        const r = checkAa(a1, a2, stmt, ctx);
+        if (!r.ok) {
+          addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
+          return false;
+        }
+        return true;
+      }
       case "given":
         return validateGivenProofStep(currStep, proofGraph);
 
       // TODO implement
-      case "aaa":
-      case "paralellogram2":
-      case "third_angle":
-      case "base_angle":
-      case "base_angle_conv":
-      case "equilat_equilang":
-      case "equilang_equilat":
-      case "aa_sim":
-      case "sss_sim":
-      case "sas_sim":
-      case "def_equilangular":
-      case "def_equilateral":
+      case "circumcenter":
+      case "incenter":
+      // TODO implement pgram reasons
       case "pgram_opp_sides":
       case "pgram_opp_sides_conv":
       case "pgram_opp_angs":

--- a/src/checker/checker/reasonApplication.ts
+++ b/src/checker/checker/reasonApplication.ts
@@ -514,7 +514,7 @@ export const checkReasonApplication = (
         const a1 = getDepStmt(reason.arguments[3], proofGraph)!;
         const a2 = getDepStmt(reason.arguments[4], proofGraph)!;
         const a3 = getDepStmt(reason.arguments[5], proofGraph)!;
-        const r = checkConTri(s1, s2, s3, a1, a2, a3, stmt, ctx);
+        const r = checkConTri(stmt, s1, s2, s3, a1, a2, a3, ctx);
         if (!r.ok) {
           addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
           return false;
@@ -542,7 +542,7 @@ export const checkReasonApplication = (
       }
       case "base_angle_conv": {
         const conAng = getDepStmt(reason.arguments[0], proofGraph)!;
-        const r = checkBaseAngle(conAng, stmt, ctx);
+        const r = checkBaseAngle(stmt, conAng, ctx);
         if (!r.ok) {
           addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
           return false;
@@ -615,7 +615,7 @@ export const checkReasonApplication = (
       case "aa_sim": {
         const a1 = getDepStmt(reason.arguments[0], proofGraph)!;
         const a2 = getDepStmt(reason.arguments[1], proofGraph)!;
-        const r = checkAa(a1, a2, stmt, ctx);
+        const r = checkAa(stmt, a1, a2, ctx);
         if (!r.ok) {
           addStmtArgMismatchError(currStep.errors, reason.function, r.failure);
           return false;

--- a/src/checker/checker/reasonChecks/polyChecks.ts
+++ b/src/checker/checker/reasonChecks/polyChecks.ts
@@ -1,6 +1,14 @@
-import { ProofContent } from "geometry-object";
+import { Angle, ProofContent } from "geometry-object";
+import { Quadrilateral } from "geometry-object/geometry/Quadrilateral";
 import { Stmt } from "../../types/checkerTypes";
 import { conAngMapper, conSegMapper } from "./argMappers";
+
+// Checks whether the quad contains the angle, retrying with all of the
+// angle's overlap-merged names when the direct label match fails.
+const quadContainsAngle = (quad: Quadrilateral, a: Angle): boolean => {
+  if (quad.contains(a)) return true;
+  return a.resolveLabel((name) => quad.a.some((qa) => qa.names.has(name))) !== null;
+};
 
 export const rectangle = (rect: Stmt, conclusion: Stmt, ctx: ProofContent) => {
   const quad = ctx.getQuadrilateral(rect.arguments[0].v);
@@ -9,7 +17,7 @@ export const rectangle = (rect: Stmt, conclusion: Stmt, ctx: ProofContent) => {
     conclusion.function === "con_ang"
   ) {
     const [a1, a2] = conAngMapper(conclusion, ctx);
-    return quad.contains(a1) && quad.contains(a2);
+    return quadContainsAngle(quad, a1) && quadContainsAngle(quad, a2);
   }
   if (conclusion.function === "con_seg") {
     const [s1, s2] = conSegMapper(conclusion, ctx);

--- a/src/checker/checker/reasonChecks/triangleChecks.ts
+++ b/src/checker/checker/reasonChecks/triangleChecks.ts
@@ -1,6 +1,6 @@
 import { ParseObj, ProofContent, Triangle } from "../../../geometry-object";
 import { Stmt } from "../../types/checkerTypes";
-import { conSegMapper, conTriMapper } from "./argMappers";
+import { conAngMapper, conSegMapper, conTriMapper } from "./argMappers";
 import {
   triangleFail,
   triangleOk,
@@ -11,6 +11,7 @@ import {
   angCenter,
   commonPt,
   findDuplicateDependencyStatements,
+  getTriFromAngs,
 } from "./utils";
 
 type TriangleAssignResult =
@@ -134,17 +135,14 @@ export const checkSas = (
     });
   }
 
-  const t1 = ctx.getTriangle(tri1.label);
-  const t2 = ctx.getTriangle(tri2.label);
-
   const t1cp2 = s11.replace(center1, "");
-  const t1p3 = t1.getThirdPoint(center1, t1cp2);
+  const t1p3 = tri1.getThirdPoint(center1, t1cp2);
 
   const t2p2 = s21.replace(center2, "");
-  const t2p3 = t2.getThirdPoint(center2, t2p2);
+  const t2p3 = tri2.getThirdPoint(center2, t2p2);
 
-  t1.orderTriangle([center1, t1cp2, t1p3], ctx);
-  t2.orderTriangle([center2, t2p2, t2p3], ctx);
+  tri1.orderTri([center1, t1cp2, t1p3], ctx);
+  tri2.orderTri([center2, t2p2, t2p3], ctx);
 
   return triangleOk();
 };
@@ -174,14 +172,11 @@ export const checkSss = (
   const s13 = r3.left;
   const s23 = r3.right;
 
-  const t1 = ctx.getTriangle(tri1.label);
-  const t2 = ctx.getTriangle(tri2.label);
-
-  t1.orderTriangle(
+  tri1.orderTri(
     [commonPt(s11, s12), commonPt(s12, s13), commonPt(s13, s11)],
     ctx,
   );
-  t2.orderTriangle(
+  tri2.orderTri(
     [commonPt(s21, s22), commonPt(s22, s23), commonPt(s23, s21)],
     ctx,
   );
@@ -237,11 +232,8 @@ export const checkAas = (
     return triangleFail("AAS_PATTERN", { t1Valid, t2Valid });
   }
 
-  const t1 = ctx.getTriangle(tri1.label);
-  const t2 = ctx.getTriangle(tri2.label);
-
-  t1.orderTriangle([a11c, a12c, s1.replace(a11c, "").replace(a12c, "")], ctx);
-  t2.orderTriangle([a21c, a22c, s2.replace(a21c, "").replace(a22c, "")], ctx);
+  tri1.orderTri([a11c, a12c, s1.replace(a11c, "").replace(a12c, "")], ctx);
+  tri2.orderTri([a21c, a22c, s2.replace(a21c, "").replace(a22c, "")], ctx);
 
   return triangleOk();
 };
@@ -283,11 +275,8 @@ export const checkAsa = (
     return triangleFail("ASA_PATTERN", { t1Valid, t2Valid });
   }
 
-  const t1 = ctx.getTriangle(tri1.label);
-  const t2 = ctx.getTriangle(tri2.label);
-
-  t1.orderTriangle([a11c, a12c, t1.getThirdPoint(a11c, a12c)], ctx);
-  t2.orderTriangle([a21c, a22c, t2.getThirdPoint(a21c, a22c)], ctx);
+  tri1.orderTri([a11c, a12c, tri1.getThirdPoint(a11c, a12c)], ctx);
+  tri2.orderTri([a21c, a22c, tri2.getThirdPoint(a21c, a22c)], ctx);
 
   return triangleOk();
 };
@@ -304,12 +293,7 @@ export const checkRhl = (
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
   const er = checkTriangleAssign(rightCon.arguments, tri1, tri2);
-  if (!er.ok)
-    return triangleFail(
-      er.failure.code,
-
-      er.failure.details,
-    );
+  if (!er.ok) return triangleFail(er.failure.code, er.failure.details);
   const h1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2);
   if (!h1.ok) return triangleFail(h1.failure.code, h1.failure.details);
   const h2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2);
@@ -338,16 +322,13 @@ export const checkRhl = (
     });
   }
 
-  const t1 = ctx.getTriangle(tri1.label);
-  const t2 = ctx.getTriangle(tri2.label);
-
   // After RHL validation, the leg contains the right vertex; the other endpoint
   // is the corresponding vertex adjacent to the right angle.
   const t1c2 = s21.replace(r1c, "");
   const t2c2 = s22.replace(r2c, "");
 
-  t1.orderTriangle([r1c, t1c2, t1.getThirdPoint(r1c, t1c2)], ctx);
-  t2.orderTriangle([r2c, t2c2, t2.getThirdPoint(r2c, t2c2)], ctx);
+  tri1.orderTri([r1c, t1c2, tri1.getThirdPoint(r1c, t1c2)], ctx);
+  tri2.orderTri([r2c, t2c2, tri2.getThirdPoint(r2c, t2c2)], ctx);
 
   return triangleOk();
 };
@@ -409,6 +390,114 @@ export const checkCpctc = (
   return triangleFail("CPCTC_CONCLUSION", { function: conclusion.function });
 };
 
+export const checkConTri = (
+  t_cong: Stmt,
+  cs1: Stmt,
+  cs2: Stmt,
+  cs3: Stmt,
+  ca1: Stmt,
+  ca2: Stmt,
+  ca3: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const dupSegs = checkDistinctDependencyStmts("def_con_tri", [cs1, cs2, cs3]);
+  if (!dupSegs.ok) return dupSegs;
+  const dupAngs = checkDistinctDependencyStmts("def_con_tri", [ca1, ca2, ca3]);
+  if (!dupAngs.ok) return dupAngs;
+
+  const [tri1, tri2] = conTriMapper(t_cong, ctx);
+
+  const assign = (stmt: Stmt) =>
+    checkTriangleAssign(stmt.arguments, tri1, tri2);
+  const s1 = assign(cs1);
+  if (!s1.ok) return triangleFail(s1.failure.code, s1.failure.details);
+  const s2 = assign(cs2);
+  if (!s2.ok) return triangleFail(s2.failure.code, s2.failure.details);
+  const s3 = assign(cs3);
+  if (!s3.ok) return triangleFail(s3.failure.code, s3.failure.details);
+  const a1 = assign(ca1);
+  if (!a1.ok) return triangleFail(a1.failure.code, a1.failure.details);
+  const a2 = assign(ca2);
+  if (!a2.ok) return triangleFail(a2.failure.code, a2.failure.details);
+  const a3 = assign(ca3);
+  if (!a3.ok) return triangleFail(a3.failure.code, a3.failure.details);
+
+  const valid =
+    tri1.hasUniqueSegs(s1.left, s2.left, s3.left) &&
+    tri2.hasUniqueSegs(s1.right, s2.right, s3.right) &&
+    tri1.hasUniqueAngs(a1.left, a2.left, a3.left) &&
+    tri2.hasUniqueAngs(a1.right, a2.right, a3.right);
+
+  if (!valid) {
+    return triangleFail("DEF_CON_TRI_PATTERN", {
+      tri1: tri1.label,
+      tri2: tri2.label,
+      segs1: [s1.left, s2.left, s3.left],
+      segs2: [s1.right, s2.right, s3.right],
+      angs1: [a1.left, a2.left, a3.left],
+      angs2: [a1.right, a2.right, a3.right],
+    });
+  }
+  return triangleOk();
+};
+
+export const checkThirdAngle = (
+  conAng1: Stmt,
+  conAng2: Stmt,
+  conAng3: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const dup = checkDistinctDependencyStmts("third_angle", [
+    conAng1,
+    conAng2,
+    conAng3,
+  ]);
+  if (!dup.ok) return dup;
+  // need to find t1 and t2 from ctx. try 2 possible arrangements and fail otherwise.
+  const [a11, a12] = conAngMapper(conAng1, ctx);
+  const [a21, a22] = conAngMapper(conAng2, ctx);
+  const t1 =
+    getTriFromAngs(a11, a21, ctx) ?? getTriFromAngs(a11, a22, ctx) ?? null;
+  const t2 =
+    getTriFromAngs(a12, a22, ctx) ?? getTriFromAngs(a21, a12, ctx) ?? null;
+  if (!t1 || !t2 || t1.isEqualTo(t2)) {
+    return triangleFail("THIRD_ANGLE_TRIANGLE_NOT_FOUND", {
+      angs1: [a11.label, a12.label],
+      angs2: [a21.label, a22.label],
+    });
+  }
+
+  // check all angles are either in t1 or t2
+  const a1 = checkTriangleAssign(conAng1.arguments, t1, t2);
+  if (!a1.ok) return triangleFail(a1.failure.code, a1.failure.details);
+  const a2 = checkTriangleAssign(conAng2.arguments, t1, t2);
+  if (!a2.ok) return triangleFail(a2.failure.code, a2.failure.details);
+  const a3 = checkTriangleAssign(conAng3.arguments, t1, t2);
+  if (!a3.ok) return triangleFail(a3.failure.code, a3.failure.details);
+
+  // order the triangles if t1 and t2 each contain exactly 3 unique angles
+  if (
+    t1.hasUniqueAngs(a1.left, a2.left, a3.left) &&
+    t2.hasUniqueAngs(a1.right, a2.right, a3.right)
+  ) {
+    t1.orderTri(
+      [angCenter(a1.left), angCenter(a2.left), angCenter(a3.left)],
+      ctx,
+    );
+    t2.orderTri(
+      [angCenter(a1.right), angCenter(a2.right), angCenter(a3.right)],
+      ctx,
+    );
+    return triangleOk();
+  }
+  return triangleFail("THIRD_ANGLE_PATTERN", {
+    tri1: t1.label,
+    tri2: t2.label,
+    angs1: [a1.left, a2.left, a3.left],
+    angs2: [a1.right, a2.right, a3.right],
+  });
+};
+
 export const checkIsosceles = (
   conSeg: Stmt,
   isoscelesStmt: Stmt,
@@ -420,5 +509,142 @@ export const checkIsosceles = (
   if (!(t.contains(s1) && t.contains(s2) && !s1.equals(s2))) {
     return triangleFail("ISOSCELES_PATTERN");
   }
+  return triangleOk();
+};
+
+export const checkBaseAngle = (
+  conSeg: Stmt,
+  conAng: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const [a1, a2] = conAngMapper(conAng, ctx);
+  if (a1.equals(a2)) {
+    return triangleFail("BASE_ANGLE_SAME_ANGLE", {
+      ang: a1.label,
+    });
+  }
+  const t = getTriFromAngs(a1, a2, ctx);
+  if (!t) {
+    return triangleFail("BASE_ANGLE_TRIANGLE_NOT_FOUND", {
+      ang1: a1.label,
+      ang2: a2.label,
+    });
+  }
+  const [s1, s2] = conSegMapper(conSeg, ctx);
+  if (!t.contains(s1) || !t.contains(s2) || s1.equals(s2)) {
+    return triangleFail("BASE_ANGLE_PATTERN", {
+      tri: t.label,
+      segs: [s1.label, s2.label],
+      angs: [a1.label, a2.label],
+    });
+  }
+  return triangleOk();
+};
+
+export const equilateralEquiangular = (
+  t_equil: Stmt,
+  t_equilang: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const [t1] = conTriMapper(t_equil, ctx);
+  const [t2] = conTriMapper(t_equilang, ctx);
+  if (t1 && t2 && t1 === t2) {
+    return triangleOk();
+  }
+  return triangleFail("EQUIL_EQUILANG_SAME_TRIANGLE", {
+    tri1: t1?.label,
+    tri2: t2?.label,
+  });
+};
+
+export const checkEquilateral = (
+  cs1: Stmt,
+  cs2: Stmt,
+  cs3: Stmt,
+  equil_t: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const dup = checkDistinctDependencyStmts("def_equilateral", [cs1, cs2, cs3]);
+  if (!dup.ok) return dup;
+  const [t] = conTriMapper(equil_t, ctx);
+  const [x1, x2] = conSegMapper(cs1, ctx);
+  const [y1, y2] = conSegMapper(cs2, ctx);
+  const [z1, z2] = conSegMapper(cs3, ctx);
+  if (x1.equals(x2) || y1.equals(y2) || z1.equals(z2)) {
+    return triangleFail("EQUILATERAL_SAME_SEG", {
+      seg1: x1.equals(x2) ? x1.label : y1.equals(y2) ? y1.label : z1.label,
+    });
+  }
+  // make a list of all 6 segments and check that each side of t has 2 collisions
+  const segs = [x1, x2, y1, y2, z1, z2];
+  const invalidSides = t.s.filter((side) => {
+    const collisions = segs.filter((s) => t.contains(s) && s.equals(side));
+    return collisions.length !== 2;
+  });
+  if (invalidSides.length > 0) {
+    return triangleFail("EQUILATERAL_SIDES_WITH_NOT_TWO_COLLISIONS", {
+      tri: t.label,
+      sides: invalidSides.map((side) => side.label),
+    });
+  }
+  return triangleOk();
+};
+
+export const checkEquiangular = (
+  ca1: Stmt,
+  ca2: Stmt,
+  ca3: Stmt,
+  equil_t: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const dup = checkDistinctDependencyStmts("def_equiangular", [ca1, ca2, ca3]);
+  if (!dup.ok) return dup;
+  const [t] = conTriMapper(equil_t, ctx);
+  const [x1, x2] = conAngMapper(ca1, ctx);
+  const [y1, y2] = conAngMapper(ca2, ctx);
+  const [z1, z2] = conAngMapper(ca3, ctx);
+  if (x1.equals(x2) || y1.equals(y2) || z1.equals(z2)) {
+    return triangleFail("EQUIANGULAR_SAME_ANG", {
+      ang1: x1.equals(x2) ? x1.label : y1.equals(y2) ? y1.label : z1.label,
+    });
+  }
+  // make a list of all 6 angles and check that each angle of t has 2 collisions
+  const angs = [x1, x2, y1, y2, z1, z2];
+  const invalidAngles = t.a.filter((angle) => {
+    const collisions = angs.filter((a) => t.contains(a) && a.equals(angle));
+    return collisions.length !== 2;
+  });
+  if (invalidAngles.length > 0) {
+    return triangleFail("EQUIANGULAR_ANGLES_WITH_NOT_TWO_COLLISIONS", {
+      tri: t.label,
+      angles: invalidAngles.map((angle) => angle.label),
+    });
+  }
+  return triangleOk();
+};
+
+export const checkAa = (
+  t_sim: Stmt,
+  conAng1: Stmt,
+  conAng2: Stmt,
+  ctx: ProofContent,
+): TriangleReasonResult => {
+  const dup = checkDistinctDependencyStmts("aas", [conAng1, conAng2]);
+  if (!dup.ok) return dup;
+  const [tri1, tri2] = conTriMapper(t_sim, ctx);
+
+  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2);
+  if (!e1.ok) return triangleFail(e1.failure.code, e1.failure.details);
+  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2);
+  if (!e2.ok) return triangleFail(e2.failure.code, e2.failure.details);
+
+  const a11c = angCenter(e1.left);
+  const a12c = angCenter(e2.left);
+  const a21c = angCenter(e1.right);
+  const a22c = angCenter(e2.right);
+
+  tri1.orderTri([a11c, a12c, tri1.getThirdPoint(a11c, a12c)], ctx);
+  tri2.orderTri([a21c, a22c, tri2.getThirdPoint(a21c, a22c)], ctx);
+
   return triangleOk();
 };

--- a/src/checker/checker/reasonChecks/triangleChecks.ts
+++ b/src/checker/checker/reasonChecks/triangleChecks.ts
@@ -1,4 +1,4 @@
-import { ParseObj, ProofContent, Triangle } from "../../../geometry-object";
+import { Obj, ParseObj, ProofContent, Triangle } from "../../../geometry-object";
 import { Stmt } from "../../types/checkerTypes";
 import { conAngMapper, conSegMapper, conTriMapper } from "./argMappers";
 import {
@@ -18,19 +18,34 @@ type TriangleAssignResult =
   | { ok: true; left: string; right: string }
   | { ok: false; failure: TriangleReasonFailure };
 
+// Returns the ParseObj form that the triangle actually recognises, resolving
+// through angle overlap names in ctx when the raw label isn't in the triangle.
+const resolveForTri = (obj: ParseObj, tri: Triangle, ctx: ProofContent): ParseObj | null => {
+  if (tri.containsParseObj(obj)) return obj;
+  if (obj.type === Obj.Angle) {
+    const resolved = ctx.getAngle(obj.v)?.resolveLabel(
+      (name) => tri.containsParseObj({ ...obj, v: name }),
+    );
+    if (resolved) return { ...obj, v: resolved };
+  }
+  return null;
+};
+
 const sortPairToTri = (
   pair: ParseObj[],
   [tri1, tri2]: [Triangle, Triangle],
+  ctx: ProofContent,
 ):
   | { ok: true; left: ParseObj; right: ParseObj }
   | { ok: false; failure: TriangleReasonFailure } => {
   const [l, r] = pair;
-  if (tri1.containsParseObj(l) && tri2.containsParseObj(r)) {
-    return { ok: true, left: l, right: r };
-  }
-  if (tri1.containsParseObj(r) && tri2.containsParseObj(l)) {
-    return { ok: true, left: r, right: l };
-  }
+  const l1 = resolveForTri(l, tri1, ctx);
+  const r2 = resolveForTri(r, tri2, ctx);
+  if (l1 && r2) return { ok: true, left: l1, right: r2 };
+
+  const r1 = resolveForTri(r, tri1, ctx);
+  const l2 = resolveForTri(l, tri2, ctx);
+  if (r1 && l2) return { ok: true, left: r1, right: l2 };
 
   return {
     ok: false,
@@ -45,8 +60,9 @@ const checkTriangleAssign = (
   pair: ParseObj[],
   tri1: Triangle,
   tri2: Triangle,
+  ctx: ProofContent,
 ): TriangleAssignResult => {
-  const sorted = sortPairToTri(pair, [tri1, tri2]);
+  const sorted = sortPairToTri(pair, [tri1, tri2], ctx);
   if (!sorted.ok) {
     return sorted;
   }
@@ -109,11 +125,11 @@ export const checkSas = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(conTri, ctx);
 
-  const a1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2);
+  const a1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2, ctx);
   if (!a1.ok) return triangleFail(a1.failure.code, a1.failure.details);
-  const a2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2);
+  const a2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2, ctx);
   if (!a2.ok) return triangleFail(a2.failure.code, a2.failure.details);
-  const ang = checkTriangleAssign(conAng.arguments, tri1, tri2);
+  const ang = checkTriangleAssign(conAng.arguments, tri1, tri2, ctx);
   if (!ang.ok) return triangleFail(ang.failure.code, ang.failure.details);
 
   const s11 = a1.left;
@@ -158,11 +174,11 @@ export const checkSss = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
-  const r1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2);
+  const r1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2, ctx);
   if (!r1.ok) return triangleFail(r1.failure.code, r1.failure.details);
-  const r2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2);
+  const r2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2, ctx);
   if (!r2.ok) return triangleFail(r2.failure.code, r2.failure.details);
-  const r3 = checkTriangleAssign(conSeg3.arguments, tri1, tri2);
+  const r3 = checkTriangleAssign(conSeg3.arguments, tri1, tri2, ctx);
   if (!r3.ok) return triangleFail(r3.failure.code, r3.failure.details);
 
   const s11 = r1.left;
@@ -206,11 +222,11 @@ export const checkAas = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
-  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2);
+  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2, ctx);
   if (!e1.ok) return triangleFail(e1.failure.code, e1.failure.details);
-  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2);
+  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2, ctx);
   if (!e2.ok) return triangleFail(e2.failure.code, e2.failure.details);
-  const es = checkTriangleAssign(conSeg.arguments, tri1, tri2);
+  const es = checkTriangleAssign(conSeg.arguments, tri1, tri2, ctx);
   if (!es.ok) return triangleFail(es.failure.code, es.failure.details);
 
   const a11 = e1.left;
@@ -249,11 +265,11 @@ export const checkAsa = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
-  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2);
+  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2, ctx);
   if (!e1.ok) return triangleFail(e1.failure.code, e1.failure.details);
-  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2);
+  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2, ctx);
   if (!e2.ok) return triangleFail(e2.failure.code, e2.failure.details);
-  const es = checkTriangleAssign(conSeg.arguments, tri1, tri2);
+  const es = checkTriangleAssign(conSeg.arguments, tri1, tri2, ctx);
   if (!es.ok) return triangleFail(es.failure.code, es.failure.details);
 
   const a11 = e1.left;
@@ -292,11 +308,11 @@ export const checkRhl = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
-  const er = checkTriangleAssign(rightCon.arguments, tri1, tri2);
+  const er = checkTriangleAssign(rightCon.arguments, tri1, tri2, ctx);
   if (!er.ok) return triangleFail(er.failure.code, er.failure.details);
-  const h1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2);
+  const h1 = checkTriangleAssign(conSeg1.arguments, tri1, tri2, ctx);
   if (!h1.ok) return triangleFail(h1.failure.code, h1.failure.details);
-  const h2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2);
+  const h2 = checkTriangleAssign(conSeg2.arguments, tri1, tri2, ctx);
   if (!h2.ok) return triangleFail(h2.failure.code, h2.failure.details);
 
   const r1 = er.left;
@@ -337,8 +353,9 @@ const checkCpctcSegment = (
   tri1: Triangle,
   tri2: Triangle,
   conclusion: Stmt,
+  ctx: ProofContent,
 ): TriangleReasonResult => {
-  const assign = checkTriangleAssign(conclusion.arguments, tri1, tri2);
+  const assign = checkTriangleAssign(conclusion.arguments, tri1, tri2, ctx);
   if (!assign.ok) {
     return triangleFail(assign.failure.code, assign.failure.details);
   }
@@ -360,7 +377,7 @@ const checkCpctcAngle = (
   conclusion: Stmt,
   ctx: ProofContent,
 ): TriangleReasonResult => {
-  const assign = checkTriangleAssign(conclusion.arguments, tri1, tri2);
+  const assign = checkTriangleAssign(conclusion.arguments, tri1, tri2, ctx);
   if (!assign.ok) {
     return triangleFail(assign.failure.code, assign.failure.details);
   }
@@ -382,7 +399,7 @@ export const checkCpctc = (
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
   if (conclusion.function === "con_seg") {
-    return checkCpctcSegment(tri1, tri2, conclusion);
+    return checkCpctcSegment(tri1, tri2, conclusion, ctx);
   }
   if (conclusion.function === "con_ang") {
     return checkCpctcAngle(tri1, tri2, conclusion, ctx);
@@ -408,7 +425,7 @@ export const checkConTri = (
   const [tri1, tri2] = conTriMapper(t_cong, ctx);
 
   const assign = (stmt: Stmt) =>
-    checkTriangleAssign(stmt.arguments, tri1, tri2);
+    checkTriangleAssign(stmt.arguments, tri1, tri2, ctx);
   const s1 = assign(cs1);
   if (!s1.ok) return triangleFail(s1.failure.code, s1.failure.details);
   const s2 = assign(cs2);
@@ -468,11 +485,11 @@ export const checkThirdAngle = (
   }
 
   // check all angles are either in t1 or t2
-  const a1 = checkTriangleAssign(conAng1.arguments, t1, t2);
+  const a1 = checkTriangleAssign(conAng1.arguments, t1, t2, ctx);
   if (!a1.ok) return triangleFail(a1.failure.code, a1.failure.details);
-  const a2 = checkTriangleAssign(conAng2.arguments, t1, t2);
+  const a2 = checkTriangleAssign(conAng2.arguments, t1, t2, ctx);
   if (!a2.ok) return triangleFail(a2.failure.code, a2.failure.details);
-  const a3 = checkTriangleAssign(conAng3.arguments, t1, t2);
+  const a3 = checkTriangleAssign(conAng3.arguments, t1, t2, ctx);
   if (!a3.ok) return triangleFail(a3.failure.code, a3.failure.details);
 
   // order the triangles if t1 and t2 each contain exactly 3 unique angles
@@ -633,9 +650,9 @@ export const checkAa = (
   if (!dup.ok) return dup;
   const [tri1, tri2] = conTriMapper(t_sim, ctx);
 
-  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2);
+  const e1 = checkTriangleAssign(conAng1.arguments, tri1, tri2, ctx);
   if (!e1.ok) return triangleFail(e1.failure.code, e1.failure.details);
-  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2);
+  const e2 = checkTriangleAssign(conAng2.arguments, tri1, tri2, ctx);
   if (!e2.ok) return triangleFail(e2.failure.code, e2.failure.details);
 
   const a11c = angCenter(e1.left);

--- a/src/checker/checker/reasonChecks/triangleChecks.ts
+++ b/src/checker/checker/reasonChecks/triangleChecks.ts
@@ -555,6 +555,23 @@ export const checkBaseAngle = (
       angs: [a1.label, a2.label],
     });
   }
+  // Each angle's center (base vertex) must appear in exactly one of the
+  // congruent segments: s1 connects the apex to one base vertex, s2 to the other.
+  // If a center appears in both segments it is the apex angle, not a base angle.
+  const a1c = a1.center.label;
+  const a2c = a2.center.label;
+  const validPattern =
+    (s1.label.includes(a1c) && !s2.label.includes(a1c) &&
+     s2.label.includes(a2c) && !s1.label.includes(a2c)) ||
+    (s1.label.includes(a2c) && !s2.label.includes(a2c) &&
+     s2.label.includes(a1c) && !s1.label.includes(a1c));
+  if (!validPattern) {
+    return triangleFail("BASE_ANGLE_PATTERN", {
+      tri: t.label,
+      segs: [s1.label, s2.label],
+      angs: [a1.label, a2.label],
+    });
+  }
   return triangleOk();
 };
 

--- a/src/checker/checker/reasonChecks/utils.ts
+++ b/src/checker/checker/reasonChecks/utils.ts
@@ -1,3 +1,4 @@
+import { Angle, ProofContent, Triangle } from "geometry-object";
 import { ErrorObj, Stmt } from "../../types/checkerTypes";
 
 /** Canonical string for comparing statement structure (function + typed args). */
@@ -63,4 +64,17 @@ export const addReasonCheckError = (
     data: details,
   });
   return errors;
+};
+
+export const getTriFromAngs = (
+  a1: Angle,
+  a2: Angle,
+  ctx: ProofContent,
+): Triangle | null => {
+  for (const triangle of ctx.getTriangles()) {
+    if (triangle.contains(a1) && triangle.contains(a2)) {
+      return triangle;
+    }
+  }
+  return null;
 };

--- a/src/checker/grammar/defs/reasons.defs.ts
+++ b/src/checker/grammar/defs/reasons.defs.ts
@@ -294,14 +294,14 @@ export const REASONS_DEFS = {
     name: "sss_sim",
     title: "SSS Triangle Similarity",
     body: "If three sides of one triangle are proportional to three sides of another triangle, then the triangles are similar.",
-    dependencies: ["con_seg", "con_seg", "con_seg"],
+    dependencies: ["sim_seg", "sim_seg", "sim_seg"],
     conclusion: "sim_tri",
   },
   sas_sim: {
     name: "sas_sim",
     title: "SAS Triangle Similarity",
     body: "If two sides of one triangle are proportional to two sides of another triangle and their included angles are congruent, then the triangles are similar.",
-    dependencies: ["con_seg", "con_ang", "con_seg"],
+    dependencies: ["sim_seg", "con_ang", "sim_seg"],
     conclusion: "sim_tri",
   },
   def_equilangular: {

--- a/src/checker/grammar/defs/reasons.defs.ts
+++ b/src/checker/grammar/defs/reasons.defs.ts
@@ -249,21 +249,21 @@ export const REASONS_DEFS = {
   },
   // unimplemented reasons that will always return true for now
   third_angle: {
-    name: "third_angle",
+    name: "third_angle", // TODO missing tri
     title: "Third Angle Theorem",
     body: "If two angles of one triangle are congruent to two angles of another triangle, then the third pair of angles are congruent.",
     dependencies: ["con_ang", "con_ang"],
     conclusion: "con_ang",
   },
   base_angle: {
-    name: "base_angle",
+    name: "base_angle", // TODO missing tri
     title: "Base Angle Theorem",
     body: "If two sides of a triangle are congruent, then the angles opposite the sides are congruent.",
     dependencies: ["con_seg"],
     conclusion: "con_ang",
   },
   base_angle_conv: {
-    name: "base_angle_conv",
+    name: "base_angle_conv", // TODO missing tri
     title: "Base Angle Theorem (Converse)",
     body: "If two angles of a triangle are congruent, then the sides opposite those angles are congruent.",
     dependencies: ["con_ang"],

--- a/src/checker/grammar/defs/reasons.defs.ts
+++ b/src/checker/grammar/defs/reasons.defs.ts
@@ -318,6 +318,20 @@ export const REASONS_DEFS = {
     dependencies: ["con_seg", "con_seg", "con_seg"],
     conclusion: "equilateral",
   },
+  def_con_tri: {
+    name: "def_con_tri",
+    title: "Def. Congruent Triangles",
+    body: "Two triangles are congruent if their corresponding sides and angles are congruent.",
+    dependencies: [
+      "con_seg",
+      "con_seg",
+      "con_seg",
+      "con_ang",
+      "con_ang",
+      "con_ang",
+    ],
+    conclusion: "con_tri",
+  },
   // parallelogram reasons
   def_parallelogram: {
     // TODO untested, maybe needs converse?
@@ -495,20 +509,6 @@ export const REASONS_DEFS = {
     body: "If a trapezoid has one pair of congruent base angles, then the trapezoid is isosceles.",
     dependencies: ["con_ang", "trapezoid"],
     conclusion: "isos_trapezoid",
-  },
-  def_con_tri: {
-    name: "def_con_tri",
-    title: "Def. Congruent Triangles",
-    body: "Two triangles are congruent if their corresponding sides and angles are congruent.",
-    dependencies: [
-      "con_seg",
-      "con_seg",
-      "con_seg",
-      "con_ang",
-      "con_ang",
-      "con_ang",
-    ],
-    conclusion: "con_tri",
   },
   circumcenter: {
     name: "circumcenter",

--- a/src/checker/grammar/defs/stmts.defs.ts
+++ b/src/checker/grammar/defs/stmts.defs.ts
@@ -84,7 +84,7 @@ export const STMTS_DEFS = {
     },
     sim_seg: {
       name: "sim_seg",
-      parameters: [segment("s1"), segment("s2"), segment("s3"), segment("s4")],
+      parameters: [segment("s1"), segment("s2")],
     },
     sim_tri: {
       name: "sim_tri",
@@ -107,8 +107,8 @@ export const STMTS_DEFS = {
       parameters: [angle("a1"), angle("a2")],
     },
     // unimplemented statements that will always return true for now
-    equilangular: {
-      name: "equilangular",
+    equiangular: {
+      name: "equiangular",
       parameters: [triangle("t")],
     },
     circumcenter: {

--- a/src/checker/grammar/defs/stmts.defs.ts
+++ b/src/checker/grammar/defs/stmts.defs.ts
@@ -111,6 +111,18 @@ export const STMTS_DEFS = {
       name: "equilangular",
       parameters: [triangle("t")],
     },
+    circumcenter: {
+      name: "circumcenter",
+      parameters: [point("p"), triangle("t")],
+    },
+    incenter: {
+      name: "incenter",
+      parameters: [point("p"), triangle("t")],
+    },
+    perp_bisector: {
+      name: "perp_bisector",
+      parameters: [segment("s1"), segment("s2"), point("p")],
+    },
     seg_bisect: {
       name: "seg_bisect",
       parameters: [segment("s1"), segment("s2")],
@@ -130,14 +142,6 @@ export const STMTS_DEFS = {
     trapezoid: {
       name: "trapezoid",
       parameters: [quadrilateral("q")],
-    },
-    circumcenter: {
-      name: "circumcenter",
-      parameters: [point("p"), triangle("t")],
-    },
-    incenter: {
-      name: "incenter",
-      parameters: [point("p"), triangle("t")],
     },
   },
   groups: {

--- a/src/checker/grammar/defs/stmts.defs.ts
+++ b/src/checker/grammar/defs/stmts.defs.ts
@@ -125,7 +125,7 @@ export const STMTS_DEFS = {
     },
     seg_bisect: {
       name: "seg_bisect",
-      parameters: [segment("s1"), segment("s2")],
+      parameters: [segment("s1"), segment("s2"), point("p")],
     },
     kite: {
       name: "kite",

--- a/src/checker/grammar/defs/stmts.txt
+++ b/src/checker/grammar/defs/stmts.txt
@@ -48,7 +48,7 @@ stmt para(Segment s1, Segment s2)
 // triangle t is isosceles (2 sides are equal length)
 stmt isosceles(Triangle t)
 
-// segment s1 and s2 are perpendicular
+// segment s1 and s2 are perpendicular, s2 intersects with s1
 stmt perp(Segment s1, Segment s2)
 
 // p is the midpoint of s

--- a/src/checker/proofChecker.ts
+++ b/src/checker/proofChecker.ts
@@ -16,6 +16,7 @@ import {
 } from "./grammar/defsParsers";
 import { ProofParser } from "./grammar/lezerParser";
 import { ErrorObj, ProofGraph, ProofObj, Stmt } from "./types/checkerTypes";
+import { ProofContent } from "../geometry-object";
 
 export type ProofGoalMatchResult = { matches: boolean; details: string };
 
@@ -23,6 +24,7 @@ export type ProofCheckerResult = {
   proof: ProofObj;
   goal: Stmt | undefined;
   graph: ProofGraph;
+  ctx: ProofContent;
   duplicateSteps: Array<[string, string]>;
   stepNumberErrors: string[];
   geometricObjectErrors: string[];
@@ -82,6 +84,7 @@ export const runProofChecker = (proof: ProofObj): ProofCheckerResult => {
       proof,
       goal,
       graph: emptyProofGraph(),
+      ctx,
       duplicateSteps: [],
       stepNumberErrors: [],
       geometricObjectErrors,
@@ -119,6 +122,7 @@ export const runProofChecker = (proof: ProofObj): ProofCheckerResult => {
     proof,
     goal,
     graph,
+    ctx,
     duplicateSteps,
     stepNumberErrors,
     geometricObjectErrors,

--- a/src/checker/proofs/overlap.txt
+++ b/src/checker/proofs/overlap.txt
@@ -4,7 +4,7 @@ premises:
 pt: E (2, 9, l), F (4.92, 5.5, bl), G (7, 3, b), H (9.08, 5.5, br), D (12, 9, r)
 tri: t_EHG t_DFG
 ang: a_EGD
-[d_1] on_line(ED, F)
+[d_1] on_line(EG, F)
 [d_2] on_line(DG, H)
 [g_1] con_seg(EG,DG) 
 [g_2] con_ang(a_GEH,a_FDG)

--- a/src/checker/proofs/s1inc2.txt
+++ b/src/checker/proofs/s1inc2.txt
@@ -4,7 +4,8 @@ premises:
 pt: J (2, 9, bl), K (5.5, 1, b), L (9, 9, br), M (5.5, 9, t)
 tri: t_JMK t_LMK
 [g_1] perp(JL,KM)
-[g_2] con_seg(JK,LK) [02]
+[g_2] con_seg(JK,LK)
+[d_1] on_line(JL, M)
 -> con_tri(t_JMK,t_LMK)
 
 steps:

--- a/src/checker/proofs/s2c2.txt
+++ b/src/checker/proofs/s2c2.txt
@@ -7,6 +7,7 @@ tri: t_FAB t_BCG t_BAD t_BCD
 [g_2] con_seg(AD, DC)
 [g_3] con_ang(a_FAB, a_GCB)
 [g_4] con_seg(AF, CG)
+[d_1] on_line(AC, D)
 -> con_ang(a_AFB, a_CGB)
 
 steps:

--- a/src/checker/proofs/s2c2incomplete.txt
+++ b/src/checker/proofs/s2c2incomplete.txt
@@ -7,6 +7,7 @@ tri: t_FAB t_BCG t_BAD t_BCD
 [g_2] con_seg(AD, DC)
 [g_3] con_ang(a_FAB, a_GCB)
 [g_4] con_seg(AF, CG)
+[d_1] on_line(AC, D)
 -> con_ang(a_AFB, a_CGB)
 
 steps:

--- a/src/checker/proofs/s2inc1.txt
+++ b/src/checker/proofs/s2inc1.txt
@@ -6,6 +6,7 @@ tri: t_PSL t_PSU t_LNU t_UQL
 [g_1] perp(LU, PS) [01]
 [g_2] con_seg(LN, QU) [02]
 [g_3] con_ang(a_LPS, a_UPS) [03]
+[d_1] on_line(LU, S)
 -> con_tri(t_LNU, t_UQL)
 
 steps:

--- a/src/checker/proofs/tests/aa_sim_correct.txt
+++ b/src/checker/proofs/tests/aa_sim_correct.txt
@@ -1,0 +1,13 @@
+// pass
+title: "Test: aa_sim (correct - two congruent angle pairs imply similarity)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_ang(a_BAC, a_EDF)
+[g_2] con_ang(a_ABC, a_DEF)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_EDF)
+[02] given(g_2) -> con_ang(a_ABC, a_DEF)
+[03] aa_sim(1, 2) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/aa_sim_incorrect.txt
+++ b/src/checker/proofs/tests/aa_sim_incorrect.txt
@@ -1,0 +1,13 @@
+// fail on step 3
+title: "Test: aa_sim (incorrect - both angle pairs from the same triangle)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_ang(a_BAC, a_ABC)
+[g_2] con_ang(a_ABC, a_ACB)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_ABC)
+[02] given(g_2) -> con_ang(a_ABC, a_ACB)
+[03] aa_sim(1, 2) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/altext_correct.txt
+++ b/src/checker/proofs/tests/altext_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: altext (correct - alternate exterior angles)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> con_ang(a_TEA, a_RFD)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] altext(1) -> con_ang(a_TEA, a_RFD)

--- a/src/checker/proofs/tests/altext_incorrect.txt
+++ b/src/checker/proofs/tests/altext_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: altext (incorrect - interior angles are not alternate exterior)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> con_ang(a_FEB, a_EFD)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] altext(1) -> con_ang(a_FEB, a_EFD)

--- a/src/checker/proofs/tests/base_angle_conv_correct.txt
+++ b/src/checker/proofs/tests/base_angle_conv_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: base_angle_conv (correct - equal base angles imply equal sides)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_ang(a_ABC, a_ACB)
+-> con_seg(AB, AC)
+
+steps:
+[01] given(g_1) -> con_ang(a_ABC, a_ACB)
+[02] base_angle_conv(1) -> con_seg(AB, AC)

--- a/src/checker/proofs/tests/base_angle_conv_incorrect.txt
+++ b/src/checker/proofs/tests/base_angle_conv_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: base_angle_conv (incorrect - angles not base angles of the same triangle)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_ang(a_BAC, a_ACB)
+-> con_seg(AB, AC)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_ACB)
+[02] base_angle_conv(1) -> con_seg(AB, AC)

--- a/src/checker/proofs/tests/base_angle_correct.txt
+++ b/src/checker/proofs/tests/base_angle_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: base_angle (correct - isosceles triangle base angles)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_seg(AB, AC)
+-> con_ang(a_ABC, a_ACB)
+
+steps:
+[01] given(g_1) -> con_seg(AB, AC)
+[02] base_angle(1) -> con_ang(a_ABC, a_ACB)

--- a/src/checker/proofs/tests/base_angle_incorrect.txt
+++ b/src/checker/proofs/tests/base_angle_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: base_angle (incorrect - angles not opposite the congruent sides)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_seg(AB, AC)
+-> con_ang(a_BAC, a_ACB)
+
+steps:
+[01] given(g_1) -> con_seg(AB, AC)
+[02] base_angle(1) -> con_ang(a_BAC, a_ACB)

--- a/src/checker/proofs/tests/corresp_ang_correct.txt
+++ b/src/checker/proofs/tests/corresp_ang_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: corresp_ang (correct - corresponding angles)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> con_ang(a_FEB, a_RFD)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] corresp_ang(1) -> con_ang(a_FEB, a_RFD)

--- a/src/checker/proofs/tests/corresp_ang_incorrect.txt
+++ b/src/checker/proofs/tests/corresp_ang_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: corresp_ang (incorrect - both angles at the same intersection)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> con_ang(a_TEA, a_FEB)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] corresp_ang(1) -> con_ang(a_TEA, a_FEB)

--- a/src/checker/proofs/tests/def_con_tri_correct.txt
+++ b/src/checker/proofs/tests/def_con_tri_correct.txt
@@ -1,0 +1,21 @@
+// pass
+title: "Test: def_con_tri (correct - all 3 side and angle pairs)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_seg(AB, DE)
+[g_2] con_seg(BC, EF)
+[g_3] con_seg(AC, DF)
+[g_4] con_ang(a_BAC, a_EDF)
+[g_5] con_ang(a_ABC, a_DEF)
+[g_6] con_ang(a_ACB, a_DFE)
+-> con_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> con_seg(AB, DE)
+[02] given(g_2) -> con_seg(BC, EF)
+[03] given(g_3) -> con_seg(AC, DF)
+[04] given(g_4) -> con_ang(a_BAC, a_EDF)
+[05] given(g_5) -> con_ang(a_ABC, a_DEF)
+[06] given(g_6) -> con_ang(a_ACB, a_DFE)
+[07] def_con_tri(1, 2, 3, 4, 5, 6) -> con_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/def_con_tri_incorrect.txt
+++ b/src/checker/proofs/tests/def_con_tri_incorrect.txt
@@ -1,0 +1,21 @@
+// fail on step 7
+title: "Test: def_con_tri (incorrect - segment pair from same triangle)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_seg(AB, DE)
+[g_2] con_seg(BC, EF)
+[g_3] con_seg(AC, BC)
+[g_4] con_ang(a_BAC, a_EDF)
+[g_5] con_ang(a_ABC, a_DEF)
+[g_6] con_ang(a_ACB, a_DFE)
+-> con_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> con_seg(AB, DE)
+[02] given(g_2) -> con_seg(BC, EF)
+[03] given(g_3) -> con_seg(AC, BC)
+[04] given(g_4) -> con_ang(a_BAC, a_EDF)
+[05] given(g_5) -> con_ang(a_ABC, a_DEF)
+[06] given(g_6) -> con_ang(a_ACB, a_DFE)
+[07] def_con_tri(1, 2, 3, 4, 5, 6) -> con_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/def_equiangular_correct.txt
+++ b/src/checker/proofs/tests/def_equiangular_correct.txt
@@ -1,0 +1,15 @@
+// pass
+title: "Test: def_equiangular (correct - all three angle pairs establish equiangular)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_ang(a_BAC, a_ABC)
+[g_2] con_ang(a_ABC, a_ACB)
+[g_3] con_ang(a_ACB, a_BAC)
+-> equiangular(t_ABC)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_ABC)
+[02] given(g_2) -> con_ang(a_ABC, a_ACB)
+[03] given(g_3) -> con_ang(a_ACB, a_BAC)
+[04] def_equiangular(1, 2, 3) -> equiangular(t_ABC)

--- a/src/checker/proofs/tests/def_equiangular_incorrect.txt
+++ b/src/checker/proofs/tests/def_equiangular_incorrect.txt
@@ -1,0 +1,15 @@
+// fail on step 4
+title: "Test: def_equiangular (incorrect - angle paired with itself)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_ang(a_BAC, a_ABC)
+[g_2] con_ang(a_ABC, a_ACB)
+[g_3] con_ang(a_BAC, a_BAC)
+-> equiangular(t_ABC)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_ABC)
+[02] given(g_2) -> con_ang(a_ABC, a_ACB)
+[03] given(g_3) -> con_ang(a_BAC, a_BAC)
+[04] def_equiangular(1, 2, 3) -> equiangular(t_ABC)

--- a/src/checker/proofs/tests/def_equilateral_correct.txt
+++ b/src/checker/proofs/tests/def_equilateral_correct.txt
@@ -1,0 +1,15 @@
+// pass
+title: "Test: def_equilateral (correct - all three side pairs establish equilateral)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_seg(AB, BC)
+[g_2] con_seg(BC, AC)
+[g_3] con_seg(AC, AB)
+-> equilateral(t_ABC)
+
+steps:
+[01] given(g_1) -> con_seg(AB, BC)
+[02] given(g_2) -> con_seg(BC, AC)
+[03] given(g_3) -> con_seg(AC, AB)
+[04] def_equilateral(1, 2, 3) -> equilateral(t_ABC)

--- a/src/checker/proofs/tests/def_equilateral_incorrect.txt
+++ b/src/checker/proofs/tests/def_equilateral_incorrect.txt
@@ -1,0 +1,15 @@
+// fail on step 4
+title: "Test: def_equilateral (incorrect - segment paired with itself)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] con_seg(AB, BC)
+[g_2] con_seg(BC, AC)
+[g_3] con_seg(AB, AB)
+-> equilateral(t_ABC)
+
+steps:
+[01] given(g_1) -> con_seg(AB, BC)
+[02] given(g_2) -> con_seg(BC, AC)
+[03] given(g_3) -> con_seg(AB, AB)
+[04] def_equilateral(1, 2, 3) -> equilateral(t_ABC)

--- a/src/checker/proofs/tests/equilang_equilat_correct.txt
+++ b/src/checker/proofs/tests/equilang_equilat_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: equilang_equilat (correct - equiangular implies equilateral)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] equiangular(t_ABC)
+-> equilateral(t_ABC)
+
+steps:
+[01] given(g_1) -> equiangular(t_ABC)
+[02] equilang_equilat(1) -> equilateral(t_ABC)

--- a/src/checker/proofs/tests/equilang_equilat_incorrect.txt
+++ b/src/checker/proofs/tests/equilang_equilat_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: equilang_equilat (incorrect - conclusion names a different triangle)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br), D (12, 9, tl), E (16, 1, br), F (20, 9, tr)
+tri: t_ABC t_DEF
+[g_1] equiangular(t_ABC)
+-> equilateral(t_DEF)
+
+steps:
+[01] given(g_1) -> equiangular(t_ABC)
+[02] equilang_equilat(1) -> equilateral(t_DEF)

--- a/src/checker/proofs/tests/equilat_equilang_correct.txt
+++ b/src/checker/proofs/tests/equilat_equilang_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: equilat_equilang (correct - equilateral implies equiangular)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br)
+tri: t_ABC
+[g_1] equilateral(t_ABC)
+-> equiangular(t_ABC)
+
+steps:
+[01] given(g_1) -> equilateral(t_ABC)
+[02] equilat_equilang(1) -> equiangular(t_ABC)

--- a/src/checker/proofs/tests/equilat_equilang_incorrect.txt
+++ b/src/checker/proofs/tests/equilat_equilang_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: equilat_equilang (incorrect - conclusion names a different triangle)"
+premises:
+pt: A (5, 9, t), B (1, 1, bl), C (9, 1, br), D (12, 9, tl), E (16, 1, br), F (20, 9, tr)
+tri: t_ABC t_DEF
+[g_1] equilateral(t_ABC)
+-> equiangular(t_DEF)
+
+steps:
+[01] given(g_1) -> equilateral(t_ABC)
+[02] equilat_equilang(1) -> equiangular(t_DEF)

--- a/src/checker/proofs/tests/perp_con_ang_correct.txt
+++ b/src/checker/proofs/tests/perp_con_ang_correct.txt
@@ -1,0 +1,12 @@
+// pass
+title: "Test: perp_con_ang (correct)"
+premises:
+pt: J (2, 9, bl), K (5.5, 1, b), L (9, 9, br), M (5.5, 9, t)
+tri: t_JMK t_LMK
+[g_1] perp(JL, KM)
+[d_1] on_line(JL, M)
+-> con_right(a_JMK, a_LMK)
+
+steps:
+[01] given(g_1) -> perp(JL, KM)
+[02] perp_con_ang(1) -> con_right(a_JMK, a_LMK)

--- a/src/checker/proofs/tests/perp_con_ang_incorrect.txt
+++ b/src/checker/proofs/tests/perp_con_ang_incorrect.txt
@@ -1,0 +1,12 @@
+// fail on step 2
+title: "Test: perp_con_ang (incorrect - angles not at intersection vertex)"
+premises:
+pt: J (2, 9, bl), K (5.5, 1, b), L (9, 9, br), M (5.5, 9, t)
+tri: t_JMK t_LMK
+[g_1] perp(JL, KM)
+[d_1] on_line(JL, M)
+-> con_right(a_KJM, a_KLM)
+
+steps:
+[01] given(g_1) -> perp(JL, KM)
+[02] perp_con_ang(1) -> con_right(a_KJM, a_KLM)

--- a/src/checker/proofs/tests/sameside_ang_correct.txt
+++ b/src/checker/proofs/tests/sameside_ang_correct.txt
@@ -1,0 +1,11 @@
+// pass
+title: "Test: sameside_ang (correct - same-side interior angles supplementary)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> supplementary(a_BEF, a_EFD)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] sameside_ang(1) -> supplementary(a_BEF, a_EFD)

--- a/src/checker/proofs/tests/sameside_ang_incorrect.txt
+++ b/src/checker/proofs/tests/sameside_ang_incorrect.txt
@@ -1,0 +1,11 @@
+// fail on step 2
+title: "Test: sameside_ang (incorrect - angles on opposite sides)"
+premises:
+pt: A (2, 8, t), B (15, 8, t), C (2, 2, b), D (15, 2, b), E (12, 8, tl), F (6, 2, b), T (13, 9, tr), R (5, 1, l)
+[d_01] transversal(A, B, T, E, C, D, R, F)
+[g_1] para(AB, CD)
+-> supplementary(a_AEF, a_EFD)
+
+steps:
+[01] given(g_1) -> para(AB, CD)
+[02] sameside_ang(1) -> supplementary(a_AEF, a_EFD)

--- a/src/checker/proofs/tests/sas_sim_correct.txt
+++ b/src/checker/proofs/tests/sas_sim_correct.txt
@@ -1,0 +1,15 @@
+// pass
+title: "Test: sas_sim (correct - two proportional sides with included congruent angle)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] sim_seg(AB, DE)
+[g_2] con_ang(a_BAC, a_EDF)
+[g_3] sim_seg(AC, DF)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> sim_seg(AB, DE)
+[02] given(g_2) -> con_ang(a_BAC, a_EDF)
+[03] given(g_3) -> sim_seg(AC, DF)
+[04] sas_sim(1, 2, 3) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/sas_sim_incorrect.txt
+++ b/src/checker/proofs/tests/sas_sim_incorrect.txt
@@ -1,0 +1,15 @@
+// fail on step 4
+title: "Test: sas_sim (incorrect - angle not included between the given sides)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] sim_seg(AB, DE)
+[g_2] con_ang(a_ACB, a_DFE)
+[g_3] sim_seg(AC, DF)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> sim_seg(AB, DE)
+[02] given(g_2) -> con_ang(a_ACB, a_DFE)
+[03] given(g_3) -> sim_seg(AC, DF)
+[04] sas_sim(1, 2, 3) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/sss_sim_correct.txt
+++ b/src/checker/proofs/tests/sss_sim_correct.txt
@@ -1,0 +1,15 @@
+// pass
+title: "Test: sss_sim (correct - three proportional side pairs imply similarity)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] sim_seg(AB, DE)
+[g_2] sim_seg(BC, EF)
+[g_3] sim_seg(AC, DF)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> sim_seg(AB, DE)
+[02] given(g_2) -> sim_seg(BC, EF)
+[03] given(g_3) -> sim_seg(AC, DF)
+[04] sss_sim(1, 2, 3) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/sss_sim_incorrect.txt
+++ b/src/checker/proofs/tests/sss_sim_incorrect.txt
@@ -1,0 +1,15 @@
+// fail on step 4
+title: "Test: sss_sim (incorrect - third segment pair from same triangle)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] sim_seg(AB, DE)
+[g_2] sim_seg(BC, EF)
+[g_3] sim_seg(AC, BC)
+-> sim_tri(t_ABC, t_DEF)
+
+steps:
+[01] given(g_1) -> sim_seg(AB, DE)
+[02] given(g_2) -> sim_seg(BC, EF)
+[03] given(g_3) -> sim_seg(AC, BC)
+[04] sss_sim(1, 2, 3) -> sim_tri(t_ABC, t_DEF)

--- a/src/checker/proofs/tests/third_angle_correct.txt
+++ b/src/checker/proofs/tests/third_angle_correct.txt
@@ -1,0 +1,13 @@
+// pass
+title: "Test: third_angle (correct)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_ang(a_BAC, a_EDF)
+[g_2] con_ang(a_ABC, a_DEF)
+-> con_ang(a_BCA, a_EFD)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_EDF)
+[02] given(g_2) -> con_ang(a_ABC, a_DEF)
+[03] third_angle(1, 2) -> con_ang(a_BCA, a_EFD)

--- a/src/checker/proofs/tests/third_angle_incorrect.txt
+++ b/src/checker/proofs/tests/third_angle_incorrect.txt
@@ -1,0 +1,13 @@
+// fail on step 3
+title: "Test: third_angle (incorrect - conclusion angle not in the triangles)"
+premises:
+pt: A (1, 9, l), B (5, 1, b), C (9, 9, r), D (13, 9, l), E (17, 1, b), F (21, 9, r)
+tri: t_ABC t_DEF
+[g_1] con_ang(a_BAC, a_EDF)
+[g_2] con_ang(a_ABC, a_DEF)
+-> con_ang(a_BAC, a_EFD)
+
+steps:
+[01] given(g_1) -> con_ang(a_BAC, a_EDF)
+[02] given(g_2) -> con_ang(a_ABC, a_DEF)
+[03] third_angle(1, 2) -> con_ang(a_BAC, a_EFD)

--- a/src/geometry-object/geometry/Angle.ts
+++ b/src/geometry-object/geometry/Angle.ts
@@ -41,6 +41,17 @@ export class Angle extends BaseGeometryObject {
     return this.names.has(other.label);
   };
 
+  // Returns the first name in this angle's names set for which check passes,
+  // or null if none pass. Use this to resolve an angle label to one that a
+  // geometric object (triangle, quad, transversal) actually recognises when
+  // the raw label is an overlapping/containing variant.
+  resolveLabel = (check: (label: string) => boolean): string | null => {
+    for (const name of this.names) {
+      if (check(name)) return name;
+    }
+    return null;
+  };
+
   contains = (obj: Point | Segment) => {
     if (obj.tag === Obj.Point) {
       return Array.from(this.names).some((name) => name.includes(obj.label));

--- a/src/geometry-object/geometry/ProofContent.ts
+++ b/src/geometry-object/geometry/ProofContent.ts
@@ -27,6 +27,8 @@ export class ProofContent {
     };
   }
 
+  getTriangles = () => this.ctx.triangles;
+
   reliesOn = (id: string, deps: string[]) => {
     // adds dependencies from one step to another
     // key is mode, value is array of modes that it depends on

--- a/src/geometry-object/geometry/Triangle.ts
+++ b/src/geometry-object/geometry/Triangle.ts
@@ -75,7 +75,7 @@ export class Triangle extends BaseGeometryObject {
     return [aa, ab, ac];
   };
 
-  orderTriangle = (p: [string, string, string], ctx: ProofContent) => {
+  orderTri = (p: [string, string, string], ctx: ProofContent) => {
     this.p = [ctx.getPoint(p[0]), ctx.getPoint(p[1]), ctx.getPoint(p[2])];
     this.s = this.buildSegments(this.p);
     this.a = this.buildAngles(this.p);
@@ -123,5 +123,25 @@ export class Triangle extends BaseGeometryObject {
     } else {
       return this.a.some((ang) => ang.equals(obj as Angle));
     }
+  };
+
+  hasUniqueAngs = (a1: string, a2: string, a3: string) => {
+    const aArr = Array.from(this.a);
+    for (let ang of [a1, a2, a3]) {
+      const idx = aArr.findIndex((a) => a.names.has(ang));
+      if (idx < 0) return false;
+      aArr.splice(idx, 1);
+    }
+    return aArr.length === 0;
+  };
+
+  hasUniqueSegs = (s1: string, s2: string, s3: string) => {
+    const sArr = Array.from(this.s);
+    for (let seg of [s1, s2, s3]) {
+      const idx = sArr.findIndex((s) => s.names.has(seg));
+      if (idx < 0) return false;
+      sArr.splice(idx, 1);
+    }
+    return sArr.length === 0;
   };
 }

--- a/src/interface/core/grammarToLayout/proofObjBaseContent.ts
+++ b/src/interface/core/grammarToLayout/proofObjBaseContent.ts
@@ -1,68 +1,53 @@
 import { ProofObj } from "checker/types/checkerTypes";
+import { ProofContent } from "geometry-object";
 import { DiagramContent } from "../builder/DiagramContent";
 import { ShowPoint } from "../types/diagramTypes";
 import { resolvePointLabelOffset } from "./pointLabelOffset";
 
-export const seedBaseContentFromPremises = (proof: ProofObj): DiagramContent => {
+export const seedBaseContentFromPremises = (
+  proof: ProofObj,
+  checkerCtx: ProofContent,
+): DiagramContent => {
   const ctx = new DiagramContent();
+
+  // Points must be added first — they carry coordinate and label-offset data that
+  // only the proof file knows about, and all other adders look up by label.
   proof.premises.points.forEach((pt) => {
     ctx.addPoint(
-      {
-        label: pt.v,
-        pt: pt.pt,
-      },
+      { label: pt.v, pt: pt.pt },
       resolvePointLabelOffset(pt.offsetCode),
       ShowPoint.Hide,
     );
   });
 
-  proof.premises.segments.forEach((seg) => {
-    if (seg.v.length !== 2) return;
-    const p1 = ctx.getPoint(seg.v[0]);
-    const p2 = ctx.getPoint(seg.v[1]);
-    if (p1 && p2) {
-      ctx.addSegment({ p1: p1.obj, p2: p2.obj });
-    }
+  // Mirror every object from the checker's already-computed ProofContent into
+  // DiagramContent by looking up points by label to get the diagram-side instances.
+  const pcCtx = checkerCtx.getCtx();
+
+  pcCtx.segments.forEach((seg) => {
+    const p1 = ctx.getPoint(seg.p1.label);
+    const p2 = ctx.getPoint(seg.p2.label);
+    if (p1 && p2) ctx.addSegment({ p1: p1.obj, p2: p2.obj });
   });
 
-  proof.premises.triangles.forEach((tri) => {
-    if (tri.v.length !== 3) return;
-    const p1 = ctx.getPoint(tri.v[0]);
-    const p2 = ctx.getPoint(tri.v[1]);
-    const p3 = ctx.getPoint(tri.v[2]);
-    if (p1 && p2 && p3) {
-      ctx.addTriangle({
-        pts: [p1.obj, p2.obj, p3.obj],
-      });
-    }
+  pcCtx.angles.forEach((ang) => {
+    const start = ctx.getPoint(ang.start.label);
+    const center = ctx.getPoint(ang.center.label);
+    const end = ctx.getPoint(ang.end.label);
+    if (start && center && end)
+      ctx.addAngle({ start: start.obj, center: center.obj, end: end.obj });
   });
 
-  proof.premises.quadrilaterals.forEach((quad) => {
-    if (quad.v.length !== 4) return;
-    const p1 = ctx.getPoint(quad.v[0]);
-    const p2 = ctx.getPoint(quad.v[1]);
-    const p3 = ctx.getPoint(quad.v[2]);
-    const p4 = ctx.getPoint(quad.v[3]);
-    if (p1 && p2 && p3 && p4) {
-      ctx.addQuadrilateral({
-        pts: [p1.obj, p2.obj, p3.obj, p4.obj],
-      });
-    }
+  pcCtx.triangles.forEach((tri) => {
+    const [p1, p2, p3] = tri.p.map((p) => ctx.getPoint(p.label));
+    if (p1 && p2 && p3) ctx.addTriangle({ pts: [p1.obj, p2.obj, p3.obj] });
   });
 
-  proof.premises.angles.forEach((ang) => {
-    if (ang.v.length !== 3) return;
-    const start = ctx.getPoint(ang.v[0]);
-    const center = ctx.getPoint(ang.v[1]);
-    const end = ctx.getPoint(ang.v[2]);
-    if (start && center && end) {
-      ctx.addAngle({
-        start: start.obj,
-        center: center.obj,
-        end: end.obj,
-      });
-    }
+  pcCtx.rectangles.forEach((quad) => {
+    const [p1, p2, p3, p4] = quad.p.map((p) => ctx.getPoint(p.label));
+    if (p1 && p2 && p3 && p4)
+      ctx.addQuadrilateral({ pts: [p1.obj, p2.obj, p3.obj, p4.obj] });
   });
+
   return ctx;
 };
-

--- a/src/interface/core/grammarToLayout/proofObjLayout.ts
+++ b/src/interface/core/grammarToLayout/proofObjLayout.ts
@@ -1,4 +1,5 @@
 import { ProofObj, ProofStep, Stmt } from "checker/types/checkerTypes";
+import { ProofContent } from "geometry-object";
 import React from "react";
 import { reasonFromFunction } from "../../theorems/reasons";
 import { makeStepMeta } from "../../theorems/utils";
@@ -24,6 +25,7 @@ const normalizeStepNumber = (step: ProofStep, fallback: number): number => {
 
 export const interactiveLayoutFromProofObj = (
   proof: ProofObj,
+  ctx: ProofContent,
   incorrectSteps?: Set<string>,
 ): LayoutProps => {
   const givenSteps = proof.steps.filter((s) => s.type === "given");
@@ -184,7 +186,7 @@ export const interactiveLayoutFromProofObj = (
   return {
     name: proof.title ?? "Imported proof",
     title: proof.title ?? "Imported proof",
-    baseContent: () => seedBaseContentFromPremises(proof),
+    baseContent: () => seedBaseContentFromPremises(proof, ctx),
     givens: givensMeta,
     proves: provesMeta,
     steps: stepMetas,

--- a/src/interface/routes/ProofObjHarness.tsx
+++ b/src/interface/routes/ProofObjHarness.tsx
@@ -1,6 +1,7 @@
 import { ProofParser } from "checker/grammar/lezerParser";
 import { runProofChecker } from "checker/proofChecker";
 import { ErrorObj, ProofObj } from "checker/types/checkerTypes";
+import { ProofContent } from "geometry-object";
 import { interactiveLayoutFromProofObj } from "interface/core/grammarToLayout/proofObjLayout";
 import { Component, createRef } from "react";
 import { NavLink } from "react-router-dom";
@@ -70,6 +71,7 @@ type ProofObjHarnessState = {
   selectedProofKey: string;
   proofText: string;
   lastGoodProof: ProofObj | null;
+  lastGoodCtx: ProofContent | null;
   parseVersion: number;
   statusMessage: string;
   incorrectSteps: Set<string>;
@@ -99,6 +101,7 @@ export class ProofObjHarness extends Component<object, ProofObjHarnessState> {
       selectedProofKey: "tutorial.txt",
       proofText: "",
       lastGoodProof: null,
+      lastGoodCtx: null,
       parseVersion: 0,
       statusMessage: "Loading proof...",
       incorrectSteps: new Set(),
@@ -211,6 +214,7 @@ export class ProofObjHarness extends Component<object, ProofObjHarnessState> {
           proofWideIssues: nextProofIssues,
           statusMessage: "Proof parsed successfully.",
           lastGoodProof: parsed,
+          lastGoodCtx: result.ctx,
           incorrectSteps: result.graph.incorrectSteps,
           proofParseSucceeded: true,
           parseVersion: prev.parseVersion + 1,
@@ -270,10 +274,11 @@ export class ProofObjHarness extends Component<object, ProofObjHarnessState> {
     interactive: InteractiveAppPageProps & { diagramAspect: AspectRatio };
     static: StaticAppPageProps & { diagramAspect: AspectRatio };
   } | null {
-    const { lastGoodProof, incorrectSteps } = this.state;
-    if (!lastGoodProof) return null;
+    const { lastGoodProof, lastGoodCtx, incorrectSteps } = this.state;
+    if (!lastGoodProof || !lastGoodCtx) return null;
     const layoutProps = interactiveLayoutFromProofObj(
       lastGoodProof,
+      lastGoodCtx,
       incorrectSteps,
     );
     const maxX = Math.max(


### PR DESCRIPTION
Implement checking behavior for (with test proofs):
- def_con_tri
- sss_sim
- sas_sim
- aa_sim
- third_angle
- base_angle
- base_angle_conv
- equilat_equilang
- equilang_equilat
- def_equiangular
- def_equilateral

And rendering/ctx checking for statement types:
- sim_seg
- perp
- perp_bisector
- seg_bisect
- equiangular
- equilateral

Changed behavior in the way that objects are added to ctx for the checker and interface so that:
* points must be defined. all objects that are referenced in the premises are automatically created (and rendered)
* any additional objects that should render or eventually be considered by the proof must be declared using the seg, ang, tri, quad entries within premises.

Also fixed bug related to how angle overlaps are used within reason checks (especially for triangles and quadrilaterals)