### PR TITLE
update feedback agent to output 3 version feedbacks with no hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "eslint.run": "onSave",
-  "eslint.format.enable": false
-}

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,8 @@ status
 
 - Total Average Iterations:1.06
 - Total Cost: $7.5615
+- Total failed: 7/120
+- Corrected total failed(in 3iter): 1/120
 
 - Average Iterations by Mutation Score:
 
@@ -35,16 +37,15 @@ status
 
 - **why?**
   - checker making error for
-    - holt_s6-2_theorem6-2-1_p1_c1.txt (2)
-    - holt_s6-2_theorem6-2-1_p2_c1.txt (2)
+    - holt_s6-2_theorem6-2-1_p1_c1.txt (2) -> fixed checker
+    - holt_s6-2_theorem6-2-1_p2_c1.txt (2) -> fixed checker
   - parsing failed --> will be fixed if step numbers are reordered in wrong
     proof generation step
     - holt_s4-4_ex4_2corrs_inc4 (also the generated altint doesn't have all
-      param anad angles are noted as EGF instead of a_EGF)
+      param and angles are noted as EGF instead of a_EGF) -> fixed prompt
     - holt_s4-5_ex3_2corrs_inc10
 
   - holt_s4-6_exer11_3corrs_inc1
     - missing step 3
     - but the corrections are correct for all 3 mutated steps
     - --> solved in 1 trial when ran again.
-

--- a/backend/feedback_agent.py
+++ b/backend/feedback_agent.py
@@ -7,7 +7,7 @@ from litellm import completion
 from solver_agent import run_solver_agent
 
 SOLVER_PROMPT_PATH = "backend/prompt/solver_with_valid_reasons_and_explanation.txt"
-FEEDBACK_PROMPT_PATH = "backend/prompt/feedbacks_gpt.txt"
+FEEDBACK_PROMPT_PATH = "backend/prompt/feedbacks_3.txt"
 
 
 def give_feedback(

--- a/backend/feedback_agent.py
+++ b/backend/feedback_agent.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from litellm import completion
 from solver_agent import run_solver_agent
 
-SOLVER_PROMPT_PATH = "backend/prompt/solver_with_valid_reasons_and_explanation.txt"
+SOLVER_PROMPT_PATH = "backend/prompt/solver_final.txt"
 FEEDBACK_PROMPT_PATH = "backend/prompt/feedbacks_3.txt"
 
 
@@ -59,19 +59,20 @@ def run_feedback_agent(
     solution_path = os.path.join(original_proof_dir, f"{proof_name}_solution.txt")
     solver_metadata_path = os.path.join(original_proof_dir, "solver_metadata.json")
     solution_proof = ""
+    hint = None
 
     if os.path.exists(solver_metadata_path):
         try:
             with open(solver_metadata_path, "r", encoding="utf-8") as f_meta:
                 metadata = json.load(f_meta)
-            if metadata.get("iterations")[0].get("llm_status") == "unfixable":
+            if metadata.get("iterations")[1].get("llm_status") == "unfixable":
                 print("The proof cannot be solved")
                 feedback = {"feedback": "unfixable"}
-            elif metadata.get("iterations")[0].get("llm_status") == "correct":
+            elif metadata.get("iterations")[1].get("llm_status") == "correct":
                 print("The student's solution is already correct")
                 feedback = {"feedback": "Good job! Your solution is already correct!!"}
             else:
-                if metadata.get("iterations")[0].get("llm_status") == "unparsable":
+                if metadata.get("iterations")[1].get("llm_status") == "unparsable":
                     print("The proof has syntax errors")
 
                 if metadata.get("solution_reached"):

--- a/backend/feedback_agent.py
+++ b/backend/feedback_agent.py
@@ -7,10 +7,16 @@ from litellm import completion
 from solver_agent import run_solver_agent
 
 SOLVER_PROMPT_PATH = "backend/prompt/solver_with_valid_reasons_and_explanation.txt"
-FEEDBACK_PROMPT_PATH = "backend/prompt/feedback_for_visual.txt"
+FEEDBACK_PROMPT_PATH = "backend/prompt/feedbacks_gpt.txt"
 
 
-def give_feedback(system_prompt, solution_proof, student_proof, checker_output) -> str:
+def give_feedback(
+    system_prompt,
+    solution_proof,
+    student_proof,
+    checker_output,
+    error_code_explanation="",
+) -> str:
     """Use LLM to provide feedback on the proof"""
     load_dotenv()
 
@@ -22,7 +28,7 @@ def give_feedback(system_prompt, solution_proof, student_proof, checker_output) 
             {"role": "system", "content": system_prompt},
             {"role": "assistant", "content": solution_proof},
             {"role": "user", "content": student_proof},
-            {"role": "assistant", "content": checker_output},
+            {"role": "assistant", "content": checker_output + error_code_explanation},
         ],
     )
 
@@ -53,36 +59,59 @@ def run_feedback_agent(
     solution_path = os.path.join(original_proof_dir, f"{proof_name}_solution.txt")
     solver_metadata_path = os.path.join(original_proof_dir, "solver_metadata.json")
     solution_proof = ""
-    solution_loaded = False
 
     if os.path.exists(solver_metadata_path):
         try:
             with open(solver_metadata_path, "r", encoding="utf-8") as f_meta:
                 metadata = json.load(f_meta)
-            if metadata.get("solution_reached"):
-                print("Solution already exists, skipping solver agent")
-                with open(solution_path, "r", encoding="utf-8") as f_sol:
-                    solution_proof = f_sol.read()
-                solution_loaded = True
+            if metadata.get("iterations")[0].get("llm_status") == "unfixable":
+                print("The proof cannot be solved")
+                feedback = {"feedback": "unfixable"}
+            elif metadata.get("iterations")[0].get("llm_status") == "correct":
+                print("The student's solution is already correct")
+                feedback = {"feedback": "Good job! Your solution is already correct!!"}
+            else:
+                if metadata.get("iterations")[0].get("llm_status") == "unparsable":
+                    print("The proof has syntax errors")
 
+                if metadata.get("solution_reached"):
+                    print("Solution already exists, skipping solver agent")
+                    with open(solution_path, "r", encoding="utf-8") as f_sol:
+                        solution_proof = f_sol.read()
+                else:
+                    try:
+                        solution_proof, _ = run_solver_agent(
+                            original_proof_dir, solver_prompt_path
+                        )
+                    except ValueError as error:
+                        print(f"Solver failed: {error}")
+
+                with open(feedback_prompt_path, encoding="utf-8") as f:
+                    feedback_prompt = f.read()
+                with open(proof_path, encoding="utf-8") as f:
+                    student_proof = f.read()
+                with open(checker_path, encoding="utf-8") as f:
+                    checker_output = f.read()
+                with open("src/checker/ERROR_CODES.md", encoding="utf-8") as f:
+                    error_code_explanation = f.read()
+
+                if solution_proof != "":
+                    llm_output = give_feedback(
+                        feedback_prompt,
+                        solution_proof,
+                        student_proof,
+                        checker_output,
+                        # error_code_explanation,
+                    )
+
+                    feedback, hint = postprocess_output(llm_output)
+                else:
+                    print("No solution is provided for the feedback. Try again.")
+                    return None
         except (json.JSONDecodeError, FileNotFoundError, PermissionError) as e:
             print(f"Metadata or solution file error, falling back to solver: {e}")
 
-    # Run the solver if the file didn't exist, flag was false, or file reading failed
-    if not solution_loaded:
-        try:
-            solution_proof, _ = run_solver_agent(original_proof_dir, solver_prompt_path)
-        except ValueError as error:
-            print(f"Solver failed: {error}")
-
-    with open(feedback_prompt_path, encoding="utf-8") as f:
-        feedback_prompt = f.read()
-    with open(proof_path, encoding="utf-8") as f:
-        student_proof = f.read()
-    with open(checker_path, encoding="utf-8") as f:
-        checker_output = f.read()
-
-    def process_metadata(feedback: str, hint: str):
+    def _process_metadata(feedback: str, hint: str):
         """save and return feedback and hint to feedback metadata"""
         metadata = {
             "proof_name": proof_name,
@@ -99,17 +128,8 @@ def run_feedback_agent(
         print(f"Feedback metadata successfully saved to {metadata_path}")
         return metadata
 
-    if solution_proof != "":
-        llm_output = give_feedback(
-            feedback_prompt, solution_proof, student_proof, checker_output
-        )
-
-        feedback, hint = postprocess_output(llm_output)
-        metadata = process_metadata(feedback, hint)
-        return metadata
-    else:
-        print("No solution is provided. Try again.")
-        return None
+    metadata = _process_metadata(feedback, hint)
+    return metadata
 
 
 if __name__ == "__main__":

--- a/backend/prompt/feedbacks_3.txt
+++ b/backend/prompt/feedbacks_3.txt
@@ -1,0 +1,99 @@
+You are a geometry proof assistant for a high school geometry course using the Socratic teaching method. Your task is to provide feedback on a student's proof.
+
+You are given:
+
+* the proof problem,
+* the correct solution,
+* the student's proof,
+* whether the student's proof is correct,
+* the first incorrect step (if any),
+* an explanation of why that step is incorrect,
+* an error code produced by the proof checker.
+
+INSTRUCTIONS:
+
+* If the entire proof is complete and correct, output:
+  {"feedback": []}
+
+* Only provide feedback for the student's first error.
+
+* If the proof is underspecified or cannot be evaluated because required premises are missing, output:
+  {"feedback": "unfixable"}
+
+* If the error code is {{3}} (parser error), generate exactly one feedback message that explains how to correct the syntax only. Do not comment on the mathematical correctness of the proof.
+
+* Otherwise, generate exactly three different feedback messages. Each message should explain the mistake from a different perspective. Do not repeat the same idea using different wording.
+
+The three feedback messages must be:
+
+1. Error explanation
+
+   * Explain the geometric concept or theorem that the student's step violates.
+   * Describe why the step is invalid without revealing the correct next step or answer.
+
+2. Alternative perspective
+
+   * Explain the mistake differently from the first feedback.
+   * This may point out an unused given, identify an incorrect assumption, describe why another theorem would be more appropriate without naming the exact theorem to use, or highlight another conceptual issue.
+   * Do not tell the student exactly what to write next.
+
+3. Socratic question
+
+   * Ask a question that encourages the student to discover the mistake themselves.
+   * The question should focus on a different aspect of the mistake than Feedback 1 and Feedback 2.
+   * Do not ask a question whose answer directly gives the correction.
+
+General rules:
+
+* Never provide hints or suggest the next proof step.
+* Never reveal the correct statement, theorem, or construction needed to continue the proof.
+* Do not mention future proof steps.
+* Keep each feedback message under 30 words.
+* Be concise.
+
+Formatting rules:
+
+* If any feedback mentions an object, step number, statement, or reason, wrap it in double curly braces.
+  Examples:
+
+  * lines: {{AB}}, {{CD}}
+  * angle: {{a_ABC}}
+  * triangle: {{t_ABC}}
+  * point: {{A}}
+  * circle: {{c_OA}}
+  * quadrilateral: {{q_ABCD}}
+  * step numbers: {{step 1}}
+  * reasons: {{SAS}}
+  * statements: {{C}}
+
+OUTPUT FORMAT (strict):
+
+Return ONLY valid JSON.
+
+If the proof is correct:
+{"feedback":[]}
+
+If the proof is unfixable:
+{"feedback":"unfixable"}
+
+If the error code is 3:
+{
+"feedback":[
+"<syntax feedback>"
+]
+}
+
+Otherwise:
+{
+"feedback":[
+"<error explanation>",
+"<alternative perspective>",
+"<Socratic question>"
+]
+}
+
+RULES:
+
+* Do NOT include text outside the JSON.
+* Do NOT include markdown.
+* Ensure the JSON is valid and parsable.

--- a/backend/prompt/solver_final.txt
+++ b/backend/prompt/solver_final.txt
@@ -48,10 +48,11 @@ Notes:
 ### Proof Construction Rules
 
 * Only use reasons from `REASONS_DEFS`.
-* Reason names, dependencies, and conclusions must exactly match their definitions.
+* Reason names, statement names, dependencies, diagramDependencies, and conclusions must exactly match their definitions.
 * Only use statements from `STMTS_DEFS`.
 * Statement names and parameter order must exactly match their definitions.
 * The generated proof must be syntactically valid and follow the same formatting as the student's proof.
+* the naming convention should follow lines or segments AB, angle a_ABC, triangle t_ABC, point A, circle c_OA where O is center and A is a pt on circle. quadrilateral q_ABCD
 
 ## OUTPUT FORMAT (strict)
 


### PR DESCRIPTION
The feedback format now follows:

"feedback": [ feedback1, feedback2, feedback3] | "unfixable" | ["<good job>"]| ["<syntax feedback>"]