### PR TITLE
feat: support resumable diagram cropping and coordinate extraction

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 /extract/__init__.py
 /extract/*.pyc
 /extract/notes/
+/extract/textbook_chapters/

--- a/backend/extract/README.md
+++ b/backend/extract/README.md
@@ -123,6 +123,40 @@ Run a different PDF:
 python -m backend.extract.pipeline "\path\to\textbook-pages.pdf"
 ```
 
+### Resume from existing proof text
+
+To skip proof-text extraction and start with diagram cropping, pass the directory containing the existing placeholder-coordinate proofs:
+
+```powershell
+python -m backend.extract.pipeline backend/extract/textbook_chapters/holt_geometry_chapter_4.pdf --existing-proofs-dir ../geo-proof-dataset/proofs
+```
+
+For a PDF named `holt_geometry_chapter_4.pdf`, the pipeline automatically selects `holt_s4-*.txt`. Use `--proof-pattern` when the PDF name does not contain the chapter number or when only a subset should be processed:
+
+```powershell
+python -m backend.extract.pipeline input.pdf --existing-proofs-dir ../geo-proof-dataset/proofs --proof-pattern "holt_s4-4_*.txt"
+```
+
+In resume mode, the pipeline renders the PDF, crops diagrams, extracts point coordinates, replaces each existing `pt:` declaration, runs the ENDER checker, and writes the checked proofs back to the existing proof directory.
+
+To continue past individual proofs whose coordinates cannot be extracted or whose completed proof fails the checker, add `--skip-errors`:
+
+```powershell
+python -m backend.extract.pipeline backend/extract/textbook_chapters/holt_geometry_chapter_2.pdf --existing-proofs-dir ../geo-proof-dataset/proofs --skip-errors
+```
+
+Skipped proofs are reported as `SKIPPED:` and their existing text is left unchanged.
+
+### Resume from existing diagram crops
+
+If diagrams have already been cropped, run coordinate extraction and proof replacement directly without rendering a PDF or calling either crop model:
+
+```powershell
+python -m backend.extract.coordinate_extraction_and_replacement ../geo-proof-dataset/textbook_diagrams ../geo-proof-dataset/proofs --proof-pattern "holt_s2-*.txt" --skip-errors
+```
+
+Existing `*_diagram_metadata.json` files are reused. Add `--refresh-metadata` to rerun coordinate extraction from the crop images. The command loads API credentials from `backend/extract/keys/.env` by default; use `--env-path` to select a different credential file.
+
 On macOS or Linux:
 
 ```bash
@@ -164,8 +198,4 @@ ender/geo-proof-dataset/
     `-- ...
 ```
 
-The command prints the absolute path of every final proof file after a
-successful run. If the LLM marks an item as not extractable, no final proof is
-created for that item. If an extractable proof has no diagram, coordinate
-extraction misses a required point, or the final proof fails the ENDER checker,
-the pipeline stops with a descriptive error.
+The command prints the absolute path of every final proof file after a successful run. If the LLM marks an item as not extractable, no final proof is created for that item. If an extractable proof has no diagram, coordinate extraction misses a required point, or the final proof fails the ENDER checker, the pipeline stops with a descriptive error.

--- a/backend/extract/configs/config.json
+++ b/backend/extract/configs/config.json
@@ -16,8 +16,8 @@
     "geo-proof-dataset/proofs/holt_s4-3_exer27_c1.txt"
   ],
   "coordinate_extraction_code_dir": "geo-proof-dataset/coordinate_extraction",
-  "final_proof_output_dir": "geo-proof-dataset/test_proofs",
-  "cropped_diagram_output_dir": "geo-proof-dataset/test_diagrams",
+  "final_proof_output_dir": "../geo-proof-dataset/proofs",
+  "cropped_diagram_output_dir": "../geo-proof-dataset/textbook_diagrams",
   "intermediate_run_output_dir": "../pipeline_test_output_raw",
   "max_pdf_text_chars": 120000
 }

--- a/backend/extract/configs/config.json
+++ b/backend/extract/configs/config.json
@@ -18,6 +18,6 @@
   "coordinate_extraction_code_dir": "geo-proof-dataset/coordinate_extraction",
   "final_proof_output_dir": "../geo-proof-dataset/proofs",
   "cropped_diagram_output_dir": "../geo-proof-dataset/textbook_diagrams",
-  "intermediate_run_output_dir": "../pipeline_test_output_raw",
+  "intermediate_run_output_dir": "../geo-proof-dataset/proofs",
   "max_pdf_text_chars": 120000
 }

--- a/backend/extract/coordinate_extraction_and_replacement.py
+++ b/backend/extract/coordinate_extraction_and_replacement.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import argparse
 import importlib
 import json
 import re
@@ -9,6 +9,7 @@ import sys
 from contextlib import chdir
 from pathlib import Path
 from typing import Any
+from dotenv import load_dotenv
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -30,12 +31,17 @@ def collect_images_coordinate(
     """Run ``coordinate_extraction.process_single_image`` and return metadata."""
     image = Path(image_path).expanduser().resolve()
     coord_dir = Path(coordinate_extraction_dir).expanduser().resolve()
+    metadata_path = image.with_name(f"{image.stem}_metadata.json")
+
+    # Preserve existing metadata and manually completed labels;
+    # --refresh-metadata deletes it to force regeneration (for errors)
+    if metadata_path.is_file():
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
 
     process_single_image = load_coordinate_runner(coord_dir)
     with chdir(coord_dir):
         process_single_image(str(image), visualize=False)
 
-    metadata_path = image.with_name(f"{image.stem}_metadata.json")
     return json.loads(metadata_path.read_text(encoding="utf-8"))
 
 
@@ -132,8 +138,7 @@ def replace_point_declaration(text: str, point_declaration: str) -> str:
             f"{missing_text}. Detected point(s): {detected_text}."
         )
 
-    # Keep every detected point, including structural points not referenced by
-    # the proof, so the final declaration preserves the complete diagram.
+    # Keep every detected point, including structural points not referenced by the proof, so the final declaration preserves the complete diagram
     lines[start_index:end_index] = [replacement]
 
     return "\n".join(lines).rstrip() + "\n"
@@ -148,7 +153,12 @@ def replace_coordinates_in_proof(
     Find the point declaration in a proof text and replace it with the
     point declaration extracted from the corresponding proof diagram image."""
     metadata = collect_images_coordinate(image_path, coordinate_extraction_dir)
-    labeled_coordinates = metadata["labeled_coordinates"]
+    # A refinement can assign proof-compatible names to detected but unlabeled vertices.
+    # Keep the original alignment for reference, and use the refined alignment when updating the proof.
+    labeled_coordinates = metadata.get(
+        "labeled_coordinates_with_refinement",
+        metadata["labeled_coordinates"],
+    )
     return replace_point_declaration(text, labeled_coordinates), metadata
 
 
@@ -197,6 +207,8 @@ def finalize_and_save_proofs(
     crops: dict[int, Path],
     coordinate_extraction_dir: str | Path,
     proofs_dir: str | Path,
+    *,
+    skip_errors: bool = False,
 ) -> list[Path]:
     """
     For each extractable item, require a diagram crop, replace the complete
@@ -209,20 +221,134 @@ def finalize_and_save_proofs(
         if item.get("status") != "extractable" or not item.get("raw_path"):
             continue
         filename = str(item["filename"])
-        if index not in crops:
-            raise RuntimeError(
-                f"{filename}: no diagram crop was found for coordinate extraction."
-            )
-
-        final_text = Path(item["raw_path"]).read_text(encoding="utf-8")
+        temporary_path: Path | None = None
         try:
+            if index not in crops:
+                raise RuntimeError("no diagram crop was found for coordinate extraction.")
+
+            final_text = Path(item["raw_path"]).read_text(encoding="utf-8")
             final_text = replace_coordinates_in_proof(
                 final_text, crops[index], coordinate_extraction_dir
             )[0]
-        except ValueError as error:
-            raise ValueError(f"{filename}: {error}") from error
 
-        final_path = save_text_with_replaced_coordinates(final_text, Path(proofs_dir) / filename)
-        run_ender_checker(final_path)
-        final_paths.append(final_path)
+            final_path = Path(proofs_dir).expanduser().resolve() / filename
+            # Check a temporary path (prevents an invalid result from overwriting an existing proof when resume mode writes in place)
+            temporary_path = final_path.with_name(f".{final_path.stem}.pending{final_path.suffix}")
+            save_text_with_replaced_coordinates(final_text, temporary_path)
+            run_ender_checker(temporary_path)
+            temporary_path.replace(final_path)
+            final_paths.append(final_path)
+        except Exception as error:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+            run_error = RuntimeError(f"{filename}: {error}")
+            if not skip_errors:
+                raise run_error from error
+            print(f"SKIPPED: {run_error}", file=sys.stderr)
     return final_paths
+
+
+def prepare_proofs(
+    proofs_dir: Path,
+    diagrams_dir: Path,
+    pattern: str,
+    refresh_metadata: bool,
+) -> tuple[list[dict[str, Any]], dict[int, Path]]:
+    """
+    Prepare a list of extractable proofs and a mapping of diagram crops.
+    If ``refresh_metadata`` is True, delete any existing metadata to force
+    regeneration of the coordinate extraction results.
+    """
+    proof_paths = sorted(proofs_dir.glob(pattern))
+    if not proof_paths:
+        raise FileNotFoundError(f"No proof files matched {pattern!r} in {proofs_dir}.")
+    items: list[dict[str, Any]] = []
+    crops: dict[int, Path] = {}
+    for index, proof_path in enumerate(proof_paths):
+        items.append(
+            {
+                "status": "extractable",
+                "filename": proof_path.name,
+                "raw_path": str(proof_path),
+            }
+        )
+        crop_path = diagrams_dir / f"{proof_path.stem}_diagram.png"
+        if not crop_path.is_file():
+            continue
+
+        crops[index] = crop_path
+        if refresh_metadata:
+            metadata_path = crop_path.with_name(f"{crop_path.stem}_metadata.json")
+            metadata_path.unlink(missing_ok=True)
+
+    return items, crops
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract diagram coordinates and update matching ENDER proofs."
+    )
+    parser.add_argument(
+        "diagrams_dir",
+        type=Path,
+        help="Directory containing *_diagram.png files.",
+    )
+    parser.add_argument(
+        "proofs_dir",
+        type=Path,
+        help="Directory containing matching proof files.",
+    )
+    parser.add_argument(
+        "--proof-pattern",
+        default="*.txt",
+        help="Proof filename pattern (default: *.txt).",
+    )
+    parser.add_argument(
+        "--coordinate-extraction-dir",
+        type=Path,
+        default=PROJECT_ROOT / "geo-proof-dataset" / "coordinate_extraction",
+        help="Coordinate extractor directory.",
+    )
+    parser.add_argument(
+        "--env-path",
+        type=Path,
+        default=PROJECT_ROOT / "backend" / "extract" / "keys" / ".env",
+        help="Credential file used for coordinate label alignment.",
+    )
+    parser.add_argument(
+        "--skip-errors",
+        action="store_true",
+        help="Report per-proof failures and continue processing.",
+    )
+    parser.add_argument(
+        "--refresh-metadata",
+        action="store_true",
+        help="Discard existing crop metadata and rerun coordinate extraction.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    load_dotenv(args.env_path.expanduser().resolve(), override=False)
+
+    diagrams_dir = args.diagrams_dir.expanduser().resolve()
+    proofs_dir = args.proofs_dir.expanduser().resolve()
+    items, crops = prepare_proofs(
+        proofs_dir,
+        diagrams_dir,
+        args.proof_pattern,
+        args.refresh_metadata,
+    )
+    final_paths = finalize_and_save_proofs(
+        items,
+        crops,
+        args.coordinate_extraction_dir,
+        proofs_dir,
+        skip_errors=args.skip_errors,
+    )
+    print("\n".join(str(path) for path in final_paths))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/extract/crop_diagram_agent.py
+++ b/backend/extract/crop_diagram_agent.py
@@ -265,6 +265,8 @@ def crop_diagrams(
                 proof_name = f"item_{item_index + 1}"
             output_path = out / f"{proof_name}_diagram.png"
             crop.save(output_path, format="PNG")
+            # If a previous run produced a metadata file for this crop, remove it to avoid confusion.
+            output_path.with_name(f"{output_path.stem}_metadata.json").unlink(missing_ok=True)
         crops[item_index] = output_path
 
     return crops

--- a/backend/extract/llm_call.py
+++ b/backend/extract/llm_call.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 from litellm import completion
 
@@ -12,11 +11,6 @@ def call_completion(
     model_key: str,
 ) -> str:
     model = config[model_key]
-    kwargs: dict[str, Any] = {"model": model, "messages": messages}
-    if os.getenv("OPENAI_API_BASE"):
-        kwargs["api_base"] = os.getenv("OPENAI_API_BASE")
-    if os.getenv("OPENAI_API_KEY"):
-        kwargs["api_key"] = os.getenv("OPENAI_API_KEY")
-    response = completion(**kwargs)
+    response = completion(model=model, messages=messages)
     print(f"LLM cost: {response._hidden_params.get('response_cost')}")
     return response.choices[0].message.content.strip()

--- a/backend/extract/pipeline.py
+++ b/backend/extract/pipeline.py
@@ -1,26 +1,106 @@
-import sys
+import argparse
+import re
 from pathlib import Path
 
 from .coordinate_extraction_and_replacement import finalize_and_save_proofs
 from .crop_diagram_agent import extract_and_crop_diagrams
-from .pdf_to_ender_agent import extract_ender_from_pdf, load_config
+from .pdf_to_ender_agent import (
+    extract_ender_from_pdf,
+    load_config,
+    render_pdf_pages,
+)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_PATH = Path(__file__).parent / "configs" / "config.json"
 
 
+def load_existing_proofs(proofs_dir: Path, pattern: str) -> list[dict[str, str]]:
+    """Build crop/finalization items from existing ENDER proof files."""
+    proof_paths = sorted(proofs_dir.glob(pattern))
+    if not proof_paths:
+        raise FileNotFoundError(
+            f"No existing proof files matched {pattern!r} in {proofs_dir}."
+        )
+    return [
+        {
+            "status": "extractable",
+            "filename": path.name,
+            "title": path.stem,
+            "content": path.read_text(encoding="utf-8"),
+            "raw_path": str(path.resolve()),
+        }
+        for path in proof_paths
+    ]
+
+
+def find_proof_pattern(pdf_path: Path) -> str:
+    """Infer ``holt_s<chapter>-*.txt`` from a chapter PDF filename."""
+    match = re.search(r"chapter[_ -]?(\d+)", pdf_path.stem, flags=re.IGNORECASE)
+    if not match:
+        raise ValueError(
+            "Cannot infer the proof filenames from the PDF name. "
+            "Pass --proof-pattern explicitly."
+        )
+    return f"holt_s{match.group(1)}-*.txt"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the ENDER extraction pipeline.")
+    parser.add_argument("pdf", type=Path, help="Source textbook PDF")
+    parser.add_argument(
+        "output_dir",
+        type=Path,
+        nargs="?",
+        help="Optional intermediate output directory",
+    )
+    parser.add_argument(
+        "--existing-proofs-dir",
+        type=Path,
+        help=(
+            "Skip proof-text extraction and use existing .txt proofs from this "
+            "directory. Coordinate-replaced proofs are written back in place."
+        ),
+    )
+    parser.add_argument(
+        "--proof-pattern",
+        help=(
+            "Glob selecting existing proofs, for example 'holt_s4-*.txt'. "
+            "Default: inferred from a PDF named '*chapter_4.pdf'."
+        ),
+    )
+    parser.add_argument(
+        "--skip-errors",
+        action="store_true",
+        help="Report per-proof coordinate/checker failures and continue.",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    pdf_path = Path(sys.argv[1]).expanduser().resolve()
+    args = parse_args()
+    pdf_path = args.pdf.expanduser().resolve()
     config = load_config(CONFIG_PATH)
     output_dir = (
-        Path(sys.argv[2]).expanduser().resolve()
-        if len(sys.argv) > 2
+        args.output_dir.expanduser().resolve()
+        if args.output_dir
         else (PROJECT_ROOT / config["intermediate_run_output_dir"]).resolve()
     )
     run_dir = output_dir / pdf_path.stem
 
-    page_images, items = extract_ender_from_pdf(pdf_path, config, run_dir / "pages", run_dir / "raw")
+    if args.existing_proofs_dir:
+        proofs_dir = args.existing_proofs_dir.expanduser().resolve()
+        pattern = args.proof_pattern or find_proof_pattern(pdf_path)
+        page_images = render_pdf_pages(
+            pdf_path, run_dir / "pages", dpi=int(config["render_dpi"])
+        )
+        items = load_existing_proofs(proofs_dir, pattern)
+    else:
+        proofs_dir = PROJECT_ROOT / config["final_proof_output_dir"]
+        page_images, items = extract_ender_from_pdf(
+            pdf_path, config, run_dir / "pages", run_dir / "raw"
+        )
+
     crops = extract_and_crop_diagrams(
         page_images, items, PROJECT_ROOT / config["cropped_diagram_output_dir"], config
     )[0]
@@ -28,7 +108,8 @@ def main() -> None:
         items,
         crops,
         PROJECT_ROOT / config["coordinate_extraction_code_dir"],
-        PROJECT_ROOT / config["final_proof_output_dir"],
+        proofs_dir,
+        skip_errors=args.skip_errors,
     )
     print("\n".join(str(path) for path in final_paths))
 

--- a/backend/extract/prompts/refine_coordinates.txt
+++ b/backend/extract/prompts/refine_coordinates.txt
@@ -1,0 +1,28 @@
+You align detected diagram coordinates with the point labels required by an
+ENDER proof.
+
+ENDER proof:
+
+{proof_text}
+
+Coordinate-extraction metadata:
+
+{metadata_json}
+
+Use the attached diagram, proof, and extraction metadata to produce coordinates
+for the point labels in the proof's `pt:` declaration.
+
+Rules:
+
+- Use every proof point label exactly once.
+- Reuse a detected coordinate when it represents a required proof point
+- If the detector missed a required point, estimate its coordinate from the
+  diagram using the same coordinate scale
+- Correct initial labels when they conflict with the proof or diagram.
+- Include vertices that have no visible point-name label.
+- Set each label position to one of: `t`, `tr`, `r`, `br`, `b`, `bl`, `l`,
+  `tl`, or `c`.
+
+Return only one ENDER point declaration in this format:
+
+pt: A(x, y, position), B(x, y, position), ...

--- a/backend/extract/refine_coordinates.py
+++ b/backend/extract/refine_coordinates.py
@@ -4,6 +4,13 @@ from pathlib import Path
 from dotenv import load_dotenv
 from litellm import completion
 
+# TODO: Integrate this script into the pipeline for automatic coordinate refinement
+# Pipeline integration still needs:
+# 1. Identify failed extractions and pass their proof, image, and metadata files to coordinate refinement
+# 2. (Optional) assign labels to unlabeled coordinates deterministically, using an LLM only for ambiguous cases
+# 3. Parse and validate the returned point declaration
+# 4. Replace the proof coordinates and rerun the checker
+# 5. Record remaining failures for retry
 
 proof_path = Path(sys.argv[1])
 image_path = Path(sys.argv[2])

--- a/backend/extract/refine_coordinates.py
+++ b/backend/extract/refine_coordinates.py
@@ -1,0 +1,37 @@
+import base64
+import sys
+from pathlib import Path
+from dotenv import load_dotenv
+from litellm import completion
+
+
+proof_path = Path(sys.argv[1])
+image_path = Path(sys.argv[2])
+metadata_path = Path(sys.argv[3])
+load_dotenv(Path(__file__).parent / "keys" / ".env", override=False)
+
+prompt_path = Path(__file__).parent / "prompts" / "refine_coordinates.txt"
+prompt = prompt_path.read_text(encoding="utf-8")
+prompt = prompt.replace("{proof_text}", proof_path.read_text(encoding="utf-8"))
+prompt = prompt.replace("{metadata_json}", metadata_path.read_text(encoding="utf-8"))
+image = base64.b64encode(image_path.read_bytes()).decode("ascii")
+
+response = completion(
+    model="gpt-5.5",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{image}",
+                        "detail": "high",
+                    },
+                },
+            ],
+        }
+    ],
+)
+print(response.choices[0].message.content.strip())


### PR DESCRIPTION
This PR updates the diagram-cropping and coordinate-extraction pipeline to support resuming interrupted runs.

## Changes

- Resume extraction from existing proofs, crops, and metadata
- Add options to refresh metadata or skip failed proofs
- Remove previous metadata when retrying failed crops
- Validate coordinate replacements before overwriting proofs
- Support additional models in `call_completion`
- Update configuration, documentation, `.gitignore`, and the dataset submodule