### PR TITLE
fix: duplicate statements throw an error

### DIFF
--- a/src/checker/ERROR_CODES.md
+++ b/src/checker/ERROR_CODES.md
@@ -37,6 +37,7 @@ Every error the checker emits is an `ErrorDetails` object (`src/checker/types/ch
 | `object_not_in_premises` | A statement argument names a geometric object (point, segment, angle, triangle, quad, circle) that doesn't exist in the geometry built from the premises. |
 | `invalid_duplicate_stmt` | Two arguments of one statement resolve to the same geometric object (when the statement disallows duplicates), or two dependency slots of a reason cite the same statement. |
 | `duplicate_step` | Two proof steps are identical: same reason, reason arguments, statement function, and statement arguments. |
+| `duplicate_conclusion` | A valid proof step re-derives a fact an earlier valid step already concluded: same statement function and matching argument objects (compared via geometric equality, ignoring order for symmetric two-argument statements). Regardless of reason, e.g. `con_ang(a_CMA, a_DMB)` then `con_ang(a_AMC, a_DMB)`. |
 | `duplicate_step_number` | The same step number label (e.g. `[03]`) is used by more than one proof step. |
 | `invalid_step_number_labels` | Some proof step labels are not numeric, so sequential numbering can't be checked. |
 | `no_step_numbers` | The proof contains no numbered proof steps at all. |

--- a/src/checker/checker/graph.ts
+++ b/src/checker/checker/graph.ts
@@ -9,7 +9,10 @@ import {
   Stmt,
 } from "../types/checkerTypes";
 import { checkReasonApplication } from "./reasonApplication";
-import { findDuplicateDependencyStatements } from "./reasonChecks/utils";
+import {
+  findDuplicateDependencyStatements,
+  sameConclusion,
+} from "./reasonChecks/utils";
 import {
   createReasonApplicabilityIndex,
   indexProofStepForReasons,
@@ -55,6 +58,9 @@ export const buildProofGraph = (
     graph.diagramPremises.set(d.stepNumber, d);
   });
   const reasonIndex = createReasonApplicabilityIndex(graph);
+
+  // Conclusions reached by earlier valid steps
+  const priorConclusions: Array<{ stepNum: string; stmt: Stmt }> = [];
 
   // Check each step and build edges
   proof.steps.forEach((step) => {
@@ -222,6 +228,26 @@ export const buildProofGraph = (
       // Check if reason is applied correctly using reason checker methods
       if (isCorrect) {
         isCorrect = checkReasonApplication(step, reasonDefs, graph, ctx);
+      }
+
+      // Reject a step that has the same fact as an earlier valid step
+      if (isCorrect && step.statement) {
+        const priorMatch = priorConclusions.find((prior) =>
+          sameConclusion(prior.stmt, step.statement!, ctx),
+        );
+        if (priorMatch) {
+          step.errors.push({
+            type: ErrorType.InvalidDupeStmt,
+            code: "duplicate_conclusion",
+            details: {
+              reason: step.reason.function,
+              duplicateOf: priorMatch.stepNum,
+            },
+          });
+          isCorrect = false;
+        } else {
+          priorConclusions.push({ stepNum, stmt: step.statement });
+        }
       }
 
       // Add edges from dependencies to this step

--- a/src/checker/checker/reasonChecks/utils.ts
+++ b/src/checker/checker/reasonChecks/utils.ts
@@ -96,6 +96,39 @@ export const stmtKey = (stmt: Stmt): string => {
 };
 
 /**
+ * True when two statements express the same geometric fact: same function and
+ * matching argument objects (resolved through `ctx`)
+ *
+ * Two-argument statements are compared without regard to argument order,
+ * catches e.g. `con_ang(a, b)` ≡ `con_ang(b, a)`.
+ *
+ * Statements with 3+ arguments are compared positionally, because
+ * some are directional — e.g. `seg_bisect(s1, s2, p)` ("s1 bisects s2 at p") is
+ * a different fact from `seg_bisect(s2, s1, p)`.
+ */
+export const sameConclusion = (
+  a: Stmt,
+  b: Stmt,
+  ctx: ProofContent,
+): boolean => {
+  if (a.function !== b.function) return false;
+
+  const objsA = stmtMapper(a, ctx);
+  const objsB = stmtMapper(b, ctx);
+  if (objsA.length !== objsB.length) return false;
+  // If any argument fails to resolve to geometry, we can't compare reliably.
+  if (objsA.some((o) => !o) || objsB.some((o) => !o)) return false;
+
+  if (objsA.length === 2) {
+    return (
+      (objsA[0].equals(objsB[0]) && objsA[1].equals(objsB[1])) ||
+      (objsA[0].equals(objsB[1]) && objsA[1].equals(objsB[0]))
+    );
+  }
+  return objsA.every((oa, i) => oa.equals(objsB[i]));
+};
+
+/**
  * If two or more entries denote the same statement (same `stmtKey`), returns
  * the first pair of indices; otherwise `null`. Use in reason checks that take
  * multiple dependency statements (e.g. SAS/SSS, altint, intersect_seg).

--- a/src/checker/errors/errorConstants.ts
+++ b/src/checker/errors/errorConstants.ts
@@ -14,6 +14,7 @@ export type ErrorCode =
   | "cycle"
   | "unused_step"
   | "duplicate_step"
+  | "duplicate_conclusion"
   | "goal_not_reached";
 
 export enum ErrorType {

--- a/src/checker/proofs/tests/examples/s1c1_dupe_stmts.txt
+++ b/src/checker/proofs/tests/examples/s1c1_dupe_stmts.txt
@@ -1,0 +1,19 @@
+// fail on step 5
+title: "S1C1 - Prove Segments Parallel"
+premises:
+pt: A (5, 9, tr), B (10, 2, br), C (1, 3, bl), D (14, 8, tr), M (7.5, 5.5, t)
+seg: AB
+tri: t_ACM t_BDM
+[d_01] intersect_seg(AB,CD,M)
+[d_02] transversal(A, C, A, A, D, B, B, B)
+[g_1] con_seg(AM,BM) 
+[g_2] con_seg(CM,DM)
+-> para(AC,BD)
+
+steps:
+[01] given(g_2) ->  con_seg(CM,DM)
+[02] given(g_1) ->  con_seg(AM,BM) 
+[03] vert_ang() -> con_ang(a_CMA, a_DMB)
+[04] sas(1, 3, 2) -> con_tri(t_ACM,t_BDM)
+[05] cpctc(4) -> con_ang(a_AMC,a_DMB)
+[06] altint_conv(5) -> para(AC, BD)


### PR DESCRIPTION
added a check that makes sure that each statement in a proof is unique.
* added an example proof with duplicate statements to test
* added the ErrorType.InvalidDupeStmt error code corresponding to 14.
* updated the ERROR_CODES.md file
* when detected, the checker returns:
```
{
  "isCorrect": false,
  "issues": [
    {
      "type": 14,
      "code": "duplicate_conclusion",
      "details": {
        "reason": "cpctc",
        "duplicateOf": "3",
        "steps": [
          "5"
        ]
      }
    }
  ]
}
```