### PR TITLE
Fix out-of-date paths to proof tests in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,4 +79,4 @@ steps:
 [01] reason(deps) -> stmt(args)
 ```
 
-Sample proofs in `src/checker/proofs/` (e.g., `tutorial.txt`, `s1c1.txt`).
+Sample proofs in `src/checker/proofs/tests/examples/` (e.g., `tutorial.txt`, `s1c1.txt`).

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Open **ProofObj Harness** from the app to edit proofs live; checker errors appea
 Run the checker on one proof file:
 
 ```bash
-npm run checkProof -- src/checker/proofs/tutorial.txt
+npm run checkProof -- src/checker/proofs/tests/examples/tutorial.txt
 ```
 
 The CLI checker does not require OpenAI/LLM configuration.
 
 ### Common proof files
 
-Proof samples live in `src/checker/proofs/` (for example: `tutorial.txt`, `tutinc.txt`, `s1c1.txt`, `s2c2.txt`).
+Proof samples live in `src/checker/proofs/tests/examples/` (for example: `tutorial.txt`, `tutinc.txt`, `s1c1.txt`, `s2c2.txt`).
 
 ### Checker HTTP server
 
@@ -179,7 +179,7 @@ Use this when you introduce a new kind of literal in proofs (new premise section
 | **Semantic premises / diagram seed** | `src/checker/checker/premises.ts` — only if givens or diagram premises must update geometric context (often `switch` on `statement.function`).                                                                                                                                                                           |
 | **Reason machinery**                 | `src/checker/utils/utils.ts` — `getGeometricObject` must support your `Obj` if any reason pulls live geometry from `ProofContent` (the function is imported by `reasonApplication.ts` and `reasonChecks/`).                                                                                                              |
 | **Interface: diagram**               | `src/interface/core/grammarToLayout/proofObjBaseContent.ts` — seed `DiagramContent` from the new premise list. Add drawing helpers under `src/interface/core/` as needed.                                                                                                                                                |
-| **Docs / samples**                   | `src/checker/glossary.md`, `src/checker/README.md`, and a proof under `src/checker/proofs/` that exercises the new syntax.                                                                                                                                                                                               |
+| **Docs / samples**                   | `src/checker/glossary.md`, `src/checker/README.md`, and a proof under `src/checker/proofs/tests/` that exercises the new syntax.                                                                                                                                                                                               |
 
 ---
 
@@ -220,7 +220,7 @@ Reasons tie dependency step numbers to a conclusion statement. They are listed i
 - [ ] **`ParseObj` / `ProofObj`** extended if premises or args introduced a new object kind
 - [ ] **`validators.ts`** (objects) and **`reasonApplication.ts`** (reason semantic check, or accept placeholder `default`)
 - [ ] **`proofObjText.tsx`** and **`proofObjDiagramAdditions.ts`** for readable text and diagram updates
-- [ ] Sample proof in **`src/checker/proofs/`** and **`npm run checkProof`** on it
+- [ ] Sample proof in **`src/checker/proofs/tests/`** and **`npm run checkProof`** on it
 
 ## Build tool (Vite)
 

--- a/src/checker/README.md
+++ b/src/checker/README.md
@@ -69,7 +69,7 @@ If you're on an Apple Silicon Mac, follow these additional steps:
 
 ```bash
 # Check a single proof file (prints harness-style issues to stdout)
-npm run checkProof src/checker/proofs/yourProof.txt
+npm run checkProof -- src/checker/proofs/tests/examples/tutorial.txt
 ```
 
 ### Programmatic Usage


### PR DESCRIPTION
This PR fixes documentation that got out of sync due to #85.

```
$ npm run checkProof -- src/checker/proofs/tutorial.txt

> ender@0.1.0 checkProof
> tsx src/checker/proofCheckerCli.ts src/checker/proofs/tutorial.txt

{
  "isCorrect": false,
  "errors": [
    {
      "type": 16,
      "code": "unexpected_error",
      "details": {
        "msg": "ENOENT: no such file or directory, open 'src/checker/proofs/tutorial.txt'"
      }
    }
  ]
}

$ npm run checkProof -- src/checker/proofs/tests/examples/tutorial.txt

> ender@0.1.0 checkProof
> tsx src/checker/proofCheckerCli.ts src/checker/proofs/tests/examples/tutorial.txt

{
  "isCorrect": true,
  "issues": []
}
```